### PR TITLE
Honor self.show_f_statistic

### DIFF
--- a/stargazer/stargazer.py
+++ b/stargazer/stargazer.py
@@ -318,7 +318,8 @@ class Stargazer:
         footer += self.generate_r2_html()
         footer += self.generate_r2_adj_html()
         footer += self.generate_resid_std_err_html()
-        footer += self.generate_f_statistic_html()
+        if self.show_f_statistic:
+            footer += self.generate_f_statistic_html()
         footer += '<tr><td colspan="' + str(self.num_models + 1) + '" style="border-bottom: 1px solid black"></td></tr>'
         footer += self.generate_notes_html()
         footer += '</table>'
@@ -535,7 +536,8 @@ class Stargazer:
         footer += self.generate_r2_latex()
         footer += self.generate_r2_adj_latex()
         footer += self.generate_resid_std_err_latex()
-        footer += self.generate_f_statistic_latex()
+        if self.show_f_statistic:
+            footer += self.generate_f_statistic_latex()
         footer += '\\hline\n\\hline \\\\[-1.8ex]\n'
         footer += self.generate_notes_latex()
         footer += '\\end{tabular}\n\\end{table}'


### PR DESCRIPTION
``stargazer`` objects have a ``show_f_statistic`` which is not honored: when setting it to ``False``, the f statistics are still shown.

This PR adds checks so that its value is honored.

By the way: it would be great to be able to set such values in a more handy way than tweaking attributes... would you accept a PR in which they can be set in the call of ``render_html`` or ``render_latex``?