### PR TITLE
Realign custom column names in rendered html

### DIFF
--- a/stargazer/stargazer.py
+++ b/stargazer/stargazer.py
@@ -219,10 +219,11 @@ class Stargazer:
                 header += '<td colspan="' + str(self.num_models) + '">'
                 header += self.column_labels + "</td></tr>"
             else:
-                header += '<tr>'
+                # The first table column holds the covariates names:
+                header += '<tr><td></td>'
                 for i, label in enumerate(self.column_labels):
-                    header += '<td colspan="' + str(self.column_separators[i])
-                    header += '">' + label + '</td>'
+                    sep = self.column_separators[i]
+                    header += '<td colspan="{}">{}</td>'.format(sep, label)
                 header += '</tr>'
 
         if self.show_model_nums:


### PR DESCRIPTION
Currently, if one uses ``custom_columns()`` and then renders to html, the column titles are not aligned (this also happens in the example provided [here](https://github.com/mwburke/stargazer/blob/master/examples.ipynb) if I replicate locally).

This PR adds the required additional cell (and makes the following two lines slightly clearer).