### PR TITLE
More informative error message on covariate_order

### DIFF
--- a/stargazer/stargazer.py
+++ b/stargazer/stargazer.py
@@ -162,7 +162,9 @@ class Stargazer:
         self.dep_var_name = name
 
     def covariate_order(self, cov_names):
-        assert set(self.cov_names).issuperset(set(cov_names)), 'Covariate order must contain subset of existing covariates'
+        missing = set(cov_names).difference(set(self.cov_names))
+        assert not missing, ('Covariate order must contain subset of existing '
+                             'covariates: {} are not.'.format(missing))
         self.original_cov_names = self.cov_names
         self.cov_names = cov_names
 


### PR DESCRIPTION
This helps the user understand what are the problematic names, which is sometimes non-trivial (e.g. with interactions)