### PR TITLE
Observations displayed as integers

### DIFF
--- a/stargazer/stargazer.py
+++ b/stargazer/stargazer.py
@@ -333,7 +333,7 @@ class Stargazer:
             return obs_text
         obs_text += '<tr><td style="text-align: left">Observations</td>'
         for md in self.model_data:
-            obs_text += '<td>' + str(md['degree_freedom'] + md['degree_freedom_resid'] + 1) + '</td>'
+            obs_text += '<td>' + str(int(md['degree_freedom'] + md['degree_freedom_resid'] + 1)) + '</td>'
         obs_text += '</tr>'
         return obs_text
 
@@ -565,7 +565,7 @@ class Stargazer:
             return obs_text
         obs_text += ' Observations '
         for md in self.model_data:
-            obs_text += '& ' + str(md['degree_freedom'] + md['degree_freedom_resid'] + 1) + ' '
+            obs_text += '& ' + str(int(md['degree_freedom'] + md['degree_freedom_resid'] + 1)) + ' '
         obs_text += '\\\\\n'
         return obs_text
 


### PR DESCRIPTION
Observations do not usually have decimals.  This change displays them as integers (without the trailing .0), which is also the standard behaviour of the Stargazer R package.