### PR TITLE
Replace df_model + df_resid + 1 with nobs when reporting observation count

### DIFF
--- a/stargazer/stargazer.py
+++ b/stargazer/stargazer.py
@@ -115,6 +115,7 @@ class Stargazer:
         data['f_p_value'] = model.f_pvalue
         data['degree_freedom'] = model.df_model
         data['degree_freedom_resid'] = model.df_resid
+        data['nobs'] = model.nobs
 
         return data
 
@@ -333,7 +334,7 @@ class Stargazer:
             return obs_text
         obs_text += '<tr><td style="text-align: left">Observations</td>'
         for md in self.model_data:
-            obs_text += '<td>' + str(md['degree_freedom'] + md['degree_freedom_resid'] + 1) + '</td>'
+            obs_text += '<td>' + str(md['nobs']) + '</td>'
         obs_text += '</tr>'
         return obs_text
 
@@ -566,7 +567,7 @@ class Stargazer:
             return obs_text
         obs_text += ' Observations '
         for md in self.model_data:
-            obs_text += '& ' + str(md['degree_freedom'] + md['degree_freedom_resid'] + 1) + ' '
+            obs_text += '& ' + str(md['nobs']) + ' '
         obs_text += '\\\\\n'
         return obs_text
 


### PR DESCRIPTION
Fixes #32, in which observation count is high by 1 when there's no constant/intercept, and is generally simpler by accessing `nobs` directly.