### PR TITLE
Use $R^2$ to report R2 in latex

### DIFF
--- a/stargazer/stargazer.py
+++ b/stargazer/stargazer.py
@@ -565,16 +565,14 @@ class Stargazer:
         return obs_text
 
     def generate_r2_latex(self):
-        r2_text = ''
-        r2_text += ' $R^2$ '
+        r2_text = ' $R^2$ '
         for md in self.model_data:
             r2_text += '& ' + self._float_format(md['r2']) + ' '
         r2_text += '\\\\\n'
         return r2_text
 
     def generate_r2_adj_latex(self):
-        r2_text = ''
-        r2_text += ' Adjusted $R^2$ '
+        r2_text = ' Adjusted $R^2$ '
         for md in self.model_data:
             r2_text += '& ' + self._float_format(md['r2_adj']) + ' '
         r2_text += '\\\\\n'

--- a/stargazer/stargazer.py
+++ b/stargazer/stargazer.py
@@ -574,7 +574,7 @@ class Stargazer:
         r2_text = ''
         if not self.show_r2:
             return r2_text
-        r2_text += ' R${2}$ '
+        r2_text += ' $R^2$ '
         for md in self.model_data:
             r2_text += '& ' + str(round(md['r2'], self.sig_digits)) + ' '
         r2_text += '\\\\\n'
@@ -584,7 +584,7 @@ class Stargazer:
         r2_text = ''
         if not self.show_r2:
             return r2_text
-        r2_text += ' Adjusted R${2}$ '
+        r2_text += ' Adjusted $R^2$ '
         for md in self.model_data:
             r2_text += '& ' + str(round(md['r2_adj'], self.sig_digits)) + ' '
         r2_text += '\\\\\n'

--- a/stargazer/stargazer.py
+++ b/stargazer/stargazer.py
@@ -566,8 +566,6 @@ class Stargazer:
 
     def generate_r2_latex(self):
         r2_text = ''
-        if not self.show_r2:
-            return r2_text
         r2_text += ' $R^2$ '
         for md in self.model_data:
             r2_text += '& ' + self._float_format(md['r2']) + ' '
@@ -576,8 +574,6 @@ class Stargazer:
 
     def generate_r2_adj_latex(self):
         r2_text = ''
-        if not self.show_r2:
-            return r2_text
         r2_text += ' Adjusted $R^2$ '
         for md in self.model_data:
             r2_text += '& ' + self._float_format(md['r2_adj']) + ' '


### PR DESCRIPTION
Fixes #34, showing that the exponent isn't superscripted in latex.