### PR TITLE
Format observations with a comma thousands separator

### DIFF
--- a/stargazer/stargazer.py
+++ b/stargazer/stargazer.py
@@ -13,7 +13,10 @@ https://CRAN.R-project.org/package=stargazer
 from __future__ import print_function
 from statsmodels.regression.linear_model import RegressionResultsWrapper
 from math import sqrt
+import locale
 
+# For formatting numbers with a locale-aware thousands separator.
+locale.setlocale(locale.LC_ALL, '')
 
 class Stargazer:
     """
@@ -369,7 +372,7 @@ class Stargazer:
         obs_text = ''
         obs_text += '<tr><td style="text-align: left">Observations</td>'
         for md in self.model_data:
-            obs_text += '<td>{:d}</td>'.format(int(md['nobs']))
+            obs_text += '<td>{:n}</td>'.format(int(md['nobs']))
         obs_text += '</tr>'
         return obs_text
 
@@ -587,7 +590,7 @@ class Stargazer:
         obs_text = ''
         obs_text += ' Observations '
         for md in self.model_data:
-            obs_text += '& {:d} '.format(int(md['nobs']))
+            obs_text += '& {:n} '.format(int(md['nobs']))
         obs_text += '\\\\\n'
         return obs_text
 

--- a/stargazer/stargazer.py
+++ b/stargazer/stargazer.py
@@ -13,10 +13,7 @@ https://CRAN.R-project.org/package=stargazer
 from __future__ import print_function
 from statsmodels.regression.linear_model import RegressionResultsWrapper
 from math import sqrt
-import locale
 
-# For formatting numbers with a locale-aware thousands separator.
-locale.setlocale(locale.LC_ALL, '')
 
 class Stargazer:
     """
@@ -372,7 +369,7 @@ class Stargazer:
         obs_text = ''
         obs_text += '<tr><td style="text-align: left">Observations</td>'
         for md in self.model_data:
-            obs_text += '<td>{:n}</td>'.format(int(md['nobs']))
+            obs_text += '<td>{:,}</td>'.format(int(md['nobs']))
         obs_text += '</tr>'
         return obs_text
 
@@ -590,7 +587,7 @@ class Stargazer:
         obs_text = ''
         obs_text += ' Observations '
         for md in self.model_data:
-            obs_text += '& {:n} '.format(int(md['nobs']))
+            obs_text += '& {:,} '.format(int(md['nobs']))
         obs_text += '\\\\\n'
         return obs_text
 


### PR DESCRIPTION
Fixes #31 using guidance from https://stackoverflow.com/a/10742904/1840471. This will format the observation count using a locale-aware thousands separator (comma or period).