### PR TITLE
Add show_stars attribute to hide/show significance stars

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ This library implements many of the customization features found in the original
 * `custom_note_label`: label notes section at bottom of table
 * `add_custom_notes`: add custom notes to section at bottom of the table
 * `append_notes`: display or hide statistical significance thresholds
+* `show_stars`: display or hide statistical significance stars
 
 These features are agnostic of the rendering type and will be applied whether the user outputs in HTML, LaTeX, etc
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ This library implements many of the customization features found in the original
 * `custom_note_label`: label notes section at bottom of table
 * `add_custom_notes`: add custom notes to section at bottom of the table
 * `append_notes`: display or hide statistical significance thresholds
-* `show_stars`: display or hide statistical significance stars
 
 These features are agnostic of the rendering type and will be applied whether the user outputs in HTML, LaTeX, etc
 

--- a/stargazer/stargazer.py
+++ b/stargazer/stargazer.py
@@ -84,6 +84,7 @@ class Stargazer:
         self.notes_label = 'Note:'
         self.notes_append = True
         self.custom_notes = []
+        self.show_stars = True
 
     def extract_data(self):
         """
@@ -216,6 +217,10 @@ class Stargazer:
         assert type(append) == bool, 'Please input True/False'
         self.notes_append = append
 
+    def show_stars(self, show):
+        assert type(show) == bool, 'Please input True/False'
+        self.show_stars = show
+
     # Begin HTML render functions
     def render_html(self):
         html = ''
@@ -328,7 +333,7 @@ class Stargazer:
         return cov_text
 
     def get_sig_icon(self, p_value, sig_char='*'):
-        if p_value is None:
+        if p_value is None or not self.show_stars:
             return ''
         if p_value >= self.sig_levels[0]:
             return ''
@@ -415,7 +420,7 @@ class Stargazer:
     def generate_notes_html(self):
         notes_text = ''
         notes_text += '<tr><td style="text-align: left">' + self.notes_label + '</td>'
-        if self.notes_append:
+        if self.notes_append and self.show_stars:
             notes_text += self.generate_p_value_section_html()
         notes_text += '</tr>'
         notes_text += self.generate_additional_notes_html()
@@ -631,7 +636,7 @@ class Stargazer:
     def generate_notes_latex(self):
         notes_text = ''
         notes_text += '\\textit{' + self.notes_label + '}'
-        if self.notes_append:
+        if self.notes_append and self.show_stars:
             notes_text += self.generate_p_value_section_latex()
         notes_text += self.generate_additional_notes_latex()
         return notes_text

--- a/stargazer/stargazer.py
+++ b/stargazer/stargazer.py
@@ -256,7 +256,7 @@ class Renderer:
                 raise exc
 
     def get_sig_icon(self, p_value, sig_char='*'):
-        if p_value is None:
+        if p_value is None or not self.show_stars:
             return ''
         if p_value >= self.sig_levels[0]:
             return ''


### PR DESCRIPTION
Fixed #28.

Aside: `append_notes` could have a more descriptive and consistent name, maybe `show_significance_note`?