### PR TITLE
Add functions to hide each of the five footer summary statistics

### DIFF
--- a/stargazer/stargazer.py
+++ b/stargazer/stargazer.py
@@ -13,7 +13,10 @@ https://CRAN.R-project.org/package=stargazer
 from __future__ import print_function
 from statsmodels.regression.linear_model import RegressionResultsWrapper
 from math import sqrt
+import locale
 
+# For formatting numbers with a locale-aware thousands separator.
+locale.setlocale(locale.LC_ALL, '')
 
 class Stargazer:
     """
@@ -369,7 +372,7 @@ class Stargazer:
         obs_text = ''
         obs_text += '<tr><td style="text-align: left">Observations</td>'
         for md in self.model_data:
-            obs_text += '<td>{:d}</td>'.format(int(md['nobs']))
+            obs_text += '<td>{:n}</td>'.format(int(md['nobs']))
         obs_text += '</tr>'
         return obs_text
 
@@ -587,7 +590,7 @@ class Stargazer:
         obs_text = ''
         obs_text += ' Observations '
         for md in self.model_data:
-            obs_text += '& {:d} '.format(int(md['nobs']))
+            obs_text += '& {:n} '.format(int(md['nobs']))
         obs_text += '\\\\\n'
         return obs_text
 

--- a/stargazer/stargazer.py
+++ b/stargazer/stargazer.py
@@ -218,7 +218,27 @@ class Stargazer:
     def append_notes(self, append):
         assert type(append) == bool, 'Please input True/False'
         self.notes_append = append
+        
+    def hide_n(self, hide=True):
+        assert type(hide) == bool, 'Please input True/False'
+        self.show_n = not hide
 
+    def hide_r2(self, hide=True):
+        assert type(hide) == bool, 'Please input True/False'
+        self.show_r2 = not hide
+
+    def hide_adj_r2(self, hide=True):
+        assert type(hide) == bool, 'Please input True/False'
+        self.show_adj_r2 = not hide
+
+    def hide_residual_std_err(self, hide=True):
+        assert type(hide) == bool, 'Please input True/False'
+        self.show_residual_std_err = not hide
+
+    def hide_f_statistic(self, hide=True):
+        assert type(hide) == bool, 'Please input True/False'
+        self.show_f_statistic = not hide
+        
     # Begin HTML render functions
     def render_html(self):
         html = ''


### PR DESCRIPTION
This adds the following five functions:
* `hide_n`
* `hide_r2`
* `hide_adj_r2`
* `hide_residual_std_err`
* `hide_f_statistic`

Each is of the form `hide_*(self, hide=True)`, making it easy to hide the element via `hide_*()`, and also an option to undo via `hide_*(False)`.

Example in action:
![image](https://user-images.githubusercontent.com/6076111/85911823-72818380-b7dc-11ea-8f0b-1a45a3b9584f.png)

This also includes #53 for a thousands separator (I'm using both in my branch).