### PR TITLE
Minor fix to generate_additional_notes() for LaTex rendering

### DIFF
--- a/stargazer/stargazer.py
+++ b/stargazer/stargazer.py
@@ -826,6 +826,6 @@ class LaTeXRenderer(Renderer):
             #     notes_text += '\\multicolumn{' + str(self.num_models) + '}{r}\\textit{' + note + '} \\\\\n'
             # else:
             #     notes_text += ' & \\multicolumn{' + str(self.num_models) + '}{r}\\textit{' + note + '} \\\\\n'
-            notes_text += ' & \\multicolumn{' + str(self.num_models) + '}{r}\\textit{' + self._escape(note) + '} \\\\\n'
+            notes_text += '\\multicolumn{' + str(self.num_models+1) + '}{r}\\textit{' + self._escape(note) + '} \\\\\n'
 
         return notes_text

--- a/stargazer/stargazer.py
+++ b/stargazer/stargazer.py
@@ -592,7 +592,7 @@ class HTMLRenderer(Renderer):
         for i, note in enumerate(self.custom_notes):
             if (i != 0) | (self.notes_append):
                 notes_text += '<tr>'
-            notes_text += '<td></td><td colspan="' + str(self.num_models) + '" style="text-align: right">' + note + '</td></tr>'
+            notes_text += '<td colspan="' + str(self.num_models+1) + '" style="text-align: right">' + note + '</td></tr>'
 
         return notes_text
 


### PR DESCRIPTION
Currently, generate_additional_notes() restricts notes to the columns with coefficients (not allowing for use of the space below the column listing variable names). In the case of a longer note (but still one line with smaller width than the table), this leads to the right-most column becoming too wide. Without larger formatting changes, this is unavoidable in the case of very long notes, but the small change here should avoid the issue for many natural notes. Short notes are entirely unaffected by this change. 