### PR TITLE
Add ability to set latex text size

### DIFF
--- a/stargazer/stargazer.py
+++ b/stargazer/stargazer.py
@@ -109,6 +109,7 @@ class Stargazer:
         self.show_stars = True
         self.table_label = None
         self.custom_latex_code = ""
+        self.font_size = 100
 
     def extract_data(self):
         """
@@ -308,7 +309,10 @@ class Stargazer:
         if type( size ) == str:
             size = size if size[0]=="\\" else "\\"+size
             self.add_custom_latex_code = size + self.add_custom_latex_code
-    
+        if type( size ) in [ int,float ]:
+            self.font_size = size
+        else:
+            assert False, "Please input font size as a string (for latex sizes) or a number for scaling (default=100)"
 
 
 class Renderer:
@@ -428,7 +432,7 @@ class HTMLRenderer(Renderer):
         if self.title_text is not None:
             header += self.title_text + '<br>'
 
-        header += '<table style="text-align:center"><tr><td colspan="'
+        header += '<table style="text-align:center; font-size:{0}%"><tr><td colspan="'.format( str(self.font_size) )
         header += str(self.num_models + 1) + '" style="border-bottom: 1px solid black"></td></tr>'
         if self.dep_var_name is not None:
             header += '<tr><td style="text-align:left"></td><td colspan="' + str(self.num_models)

--- a/stargazer/stargazer.py
+++ b/stargazer/stargazer.py
@@ -108,6 +108,7 @@ class Stargazer:
         self.custom_notes = []
         self.show_stars = True
         self.table_label = None
+        self.latex_text_size = ""
 
     def extract_data(self):
         """
@@ -273,6 +274,13 @@ class Stargazer:
     def append_notes(self, append):
         assert type(append) == bool, 'Please input True/False'
         self.notes_append = append
+
+    def latex_size(self, size):
+        latex_sizes = [ "tiny", "scriptsize", "footnotesize", "small", "normalsize",
+                        "large", "Large", "LARGE", "huge", "Huge" ]
+        assert type(size) == str, "Please input a string argument for latex text size among:\n"+str(latex_sizes)
+        assert size in latex_sizes, "Please input a valid latex text size among the following:\n"+str(latex_sizes)
+        self.latex_text_size = size
 
     def render_html(self, *args, **kwargs):
         return HTMLRenderer(self).render(*args, **kwargs)
@@ -637,7 +645,8 @@ class LaTeXRenderer(Renderer):
     def generate_header(self, only_tabular=False):
         header = ''
         if not only_tabular:
-            header += '\\begin{table}[!htbp] \\centering\n'
+            size = "" if self.latex_text_size == "" else "\\"+self.latex_text_size
+            header += '\\begin{table}[!htbp] \\centering ' + size + ' \n'
             if not self.show_header:
                 return header
 

--- a/stargazer/stargazer.py
+++ b/stargazer/stargazer.py
@@ -108,7 +108,7 @@ class Stargazer:
         self.custom_notes = []
         self.show_stars = True
         self.table_label = None
-        self.latex_text_size = ""
+        self.custom_latex_code = ""
 
     def extract_data(self):
         """
@@ -275,12 +275,12 @@ class Stargazer:
         assert type(append) == bool, 'Please input True/False'
         self.notes_append = append
 
-    def latex_size(self, size):
-        latex_sizes = [ "tiny", "scriptsize", "footnotesize", "small", "normalsize",
-                        "large", "Large", "LARGE", "huge", "Huge" ]
-        assert type(size) == str, "Please input a string argument for latex text size among:\n"+str(latex_sizes)
-        assert size in latex_sizes, "Please input a valid latex text size among the following:\n"+str(latex_sizes)
-        self.latex_text_size = size
+    def add_custom_latex_code(self, code):
+        assert type(code) in [ list, str ], "Please input custom latex code as a string or list of strings"
+        if type(code) == list:
+            assert sum([int(type(n) != str) for n in code]) == 0, "Custom latex code must be strings"
+            code = " ".join( code )
+        self.custom_latex_code += code
 
     def render_html(self, *args, **kwargs):
         return HTMLRenderer(self).render(*args, **kwargs)
@@ -303,6 +303,12 @@ class Stargazer:
             The LaTeX code.
         """
         return LaTeXRenderer(self, escape=escape).render(*args, **kwargs)
+
+    def set_font_size( self, size ):
+        if type( size ) == str:
+            size = size if size[0]=="\\" else "\\"+size
+            self.add_custom_latex_code = size + self.add_custom_latex_code
+    
 
 
 class Renderer:
@@ -645,8 +651,7 @@ class LaTeXRenderer(Renderer):
     def generate_header(self, only_tabular=False):
         header = ''
         if not only_tabular:
-            size = "" if self.latex_text_size == "" else "\\"+self.latex_text_size
-            header += '\\begin{table}[!htbp] \\centering ' + size + ' \n'
+            header += '\\begin{table}[!htbp] \\centering ' + self.custom_latex_code + ' \n'
             if not self.show_header:
                 return header
 


### PR DESCRIPTION
Added ability to set latex font size. Default is to not add a size specification (which is equivalent to the current output). If user specifies a latex font size, asserts that font size is string and valid latex font size.

I'm less familiar with HTML, so I'm not exactly sure the right way to create an equivalent, but I'm happy to implement something similar for setting the width percentage in the table style tag if that would help.