### PR TITLE
Add an excel renderer to the package

### DIFF
--- a/stargazer/stargazer.py
+++ b/stargazer/stargazer.py
@@ -25,7 +25,7 @@ class LineLocation(Enum):
     BODY_TOP = 'bt'
     BODY_BOTTOM = 'bb'
     FOOTER_TOP = 'ft'
-    FOOTER_BOOTM = 'fb'
+    FOOTER_BOTTOM = 'fb'
 
 
 class Stargazer:
@@ -538,7 +538,7 @@ class HTMLRenderer(Renderer):
             if getattr(self, f'show_{attr}'):
                 footer += self.generate_stat(stat, self._stats_labels[attr])
 
-        footer += self.generate_custom_lines(LineLocation.FOOTER_BOOTM)
+        footer += self.generate_custom_lines(LineLocation.FOOTER_BOTTOM)
         footer += '<tr><td colspan="' + str(self.num_models + 1) + '" style="border-bottom: 1px solid black"></td></tr>'
         if self.show_notes:
             footer += self.generate_notes()
@@ -769,7 +769,7 @@ class LaTeXRenderer(Renderer):
             if getattr(self, f'show_{attr}'):
                 footer += self.generate_stat(stat, self._stats_labels[attr])
 
-        footer += self.generate_custom_lines(LineLocation.FOOTER_BOOTM)
+        footer += self.generate_custom_lines(LineLocation.FOOTER_BOTTOM)
         footer += '\\hline\n\\hline \\\\[-1.8ex]\n'
         if self.show_notes:
             footer += self.generate_notes()

--- a/stargazer/stargazer.py
+++ b/stargazer/stargazer.py
@@ -876,7 +876,7 @@ class ExcelRenderer(Renderer):
             row += 1
 
         if self.dep_var_name is not None:
-            ws.write(row, col, '', wb.add_format({'top': 6, 'bottom': 1}))
+            ws.write(row, col, '', wb.add_format({'top': 6, 'bottom': 0}))
             ws.merge_range(row, col+1, 
                 row, col+self.num_models, 
                 self.dep_var_name + self.dependent_variable, 


### PR DESCRIPTION
This PR fixes #77: implementing an excel renderer.

The excel renderer is based on the `xlsxwriter` package. 

Example:

```python
import pandas as pd
from sklearn import datasets
import statsmodels.api as sm
from stargazer.stargazer import Stargazer

diabetes = datasets.load_diabetes()
df = pd.DataFrame(diabetes.data)
df.columns = ['Age', 'Sex', 'BMI', 'ABP', 'S1', 'S2', 'S3', 'S4', 'S5', 'S6']
df['target'] = diabetes.target

est = sm.OLS(endog=df['target'], exog=sm.add_constant(df[df.columns[0:4]])).fit()
est2 = sm.OLS(endog=df['target'], exog=sm.add_constant(df[df.columns[0:6]])).fit()
stargazer = Stargazer([est, est2])
```

Calling the excel renderer works similar to the html and LaTeX renderers:

```python
stargazer.render_excel(filename='test.xlsx')
```

Which returns the following table in the test.xlsx file:

<img width="413" alt="Table" src="https://user-images.githubusercontent.com/9055281/152659184-d4f1463c-c448-48e7-a3d0-0e26891d0877.png">
