### PR TITLE
Change dependent_variable_name function

### DIFF
--- a/stargazer/stargazer.py
+++ b/stargazer/stargazer.py
@@ -237,7 +237,7 @@ class Stargazer:
 
     def dependent_variable_name(self, name):
         assert type(name) == str, 'Please input a string to use as the depedent variable name'
-        self.dep_var_name = name
+        self.dependent_variable = name
 
     def covariate_order(self, cov_names):
         missing = set(cov_names).difference(set(self.cov_names))


### PR DESCRIPTION
dependent_variable_name used to change the phrase "dependent variable:" instead of the actual dependent variable name. I have updated the function to be able to change the name of the dependent variable in the table.

For example, it used to be "dependent variable: target" and after applying stargazer.dependent_variable_name("new name") it becomes 
"new name: target" instead of "dependent variable: new name"