### PR TITLE
Rename interaction terms

### DIFF
--- a/examples.ipynb
+++ b/examples.ipynb
@@ -46,7 +46,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -56,18 +56,18 @@
        "<tr><td style=\"text-align:left\"></td><td colspan=\"2\"><em>Dependent variable: target</em></td></tr><tr><td style=\"text-align:left\"></td><tr><td style=\"text-align:left\"></td><td>(1)</td><td>(2)</td></tr>\n",
        "<tr><td colspan=\"3\" style=\"border-bottom: 1px solid black\"></td></tr>\n",
        "\n",
-       "<tr><td style=\"text-align:left\">ABP</td><td>416.673<sup>***</sup></td><td>397.581<sup>***</sup></td></tr>\n",
-       "<tr><td style=\"text-align:left\"></td><td>(69.495)</td><td>(70.870)</td></tr>\n",
        "<tr><td style=\"text-align:left\">Age</td><td>37.241<sup></sup></td><td>24.703<sup></sup></td></tr>\n",
        "<tr><td style=\"text-align:left\"></td><td>(64.117)</td><td>(65.411)</td></tr>\n",
+       "<tr><td style=\"text-align:left\">Sex</td><td>-106.576<sup>*</sup></td><td>-82.862<sup></sup></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td>(62.125)</td><td>(64.851)</td></tr>\n",
        "<tr><td style=\"text-align:left\">BMI</td><td>787.182<sup>***</sup></td><td>789.744<sup>***</sup></td></tr>\n",
        "<tr><td style=\"text-align:left\"></td><td>(65.424)</td><td>(66.887)</td></tr>\n",
+       "<tr><td style=\"text-align:left\">ABP</td><td>416.673<sup>***</sup></td><td>397.581<sup>***</sup></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td>(69.495)</td><td>(70.870)</td></tr>\n",
        "<tr><td style=\"text-align:left\">S1</td><td></td><td>197.848<sup></sup></td></tr>\n",
        "<tr><td style=\"text-align:left\"></td><td></td><td>(143.812)</td></tr>\n",
        "<tr><td style=\"text-align:left\">S2</td><td></td><td>-169.243<sup></sup></td></tr>\n",
        "<tr><td style=\"text-align:left\"></td><td></td><td>(142.744)</td></tr>\n",
-       "<tr><td style=\"text-align:left\">Sex</td><td>-106.576<sup>*</sup></td><td>-82.862<sup></sup></td></tr>\n",
-       "<tr><td style=\"text-align:left\"></td><td>(62.125)</td><td>(64.851)</td></tr>\n",
        "<tr><td style=\"text-align:left\">const</td><td>152.133<sup>***</sup></td><td>152.133<sup>***</sup></td></tr>\n",
        "<tr><td style=\"text-align:left\"></td><td>(2.853)</td><td>(2.853)</td></tr>\n",
        "\n",
@@ -76,10 +76,10 @@
        "<tr><td colspan=\"3\" style=\"border-bottom: 1px solid black\"></td></tr><tr><td style=\"text-align: left\">Note:</td><td colspan=\"2\" style=\"text-align: right\"><sup>*</sup>p&lt;0.1; <sup>**</sup>p&lt;0.05; <sup>***</sup>p&lt;0.01</td></tr></table>"
       ],
       "text/plain": [
-       "<stargazer.stargazer.Stargazer at 0x7fc74103eb50>"
+       "<stargazer.stargazer.Stargazer at 0x14e70e74910>"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -94,7 +94,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -109,18 +109,18 @@
       "\\cr \\cline{2-3}\n",
       "\\\\[-1.8ex] & (1) & (2) \\\\\n",
       "\\hline \\\\[-1.8ex]\n",
-      " ABP & 416.673$^{***}$ & 397.581$^{***}$ \\\\\n",
-      "& (69.495) & (70.870) \\\\\n",
       " Age & 37.241$^{}$ & 24.703$^{}$ \\\\\n",
       "& (64.117) & (65.411) \\\\\n",
+      " Sex & -106.576$^{*}$ & -82.862$^{}$ \\\\\n",
+      "& (62.125) & (64.851) \\\\\n",
       " BMI & 787.182$^{***}$ & 789.744$^{***}$ \\\\\n",
       "& (65.424) & (66.887) \\\\\n",
+      " ABP & 416.673$^{***}$ & 397.581$^{***}$ \\\\\n",
+      "& (69.495) & (70.870) \\\\\n",
       " S1 & & 197.848$^{}$ \\\\\n",
       "& & (143.812) \\\\\n",
       " S2 & & -169.243$^{}$ \\\\\n",
       "& & (142.744) \\\\\n",
-      " Sex & -106.576$^{*}$ & -82.862$^{}$ \\\\\n",
-      "& (62.125) & (64.851) \\\\\n",
       " const & 152.133$^{***}$ & 152.133$^{***}$ \\\\\n",
       "& (2.853) & (2.853) \\\\\n",
       "\\hline \\\\[-1.8ex]\n",
@@ -150,7 +150,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -160,18 +160,18 @@
        "<tr><td style=\"text-align:left\"></td><td colspan=\"2\"><em>Dependent variable: target</em></td></tr><tr><td style=\"text-align:left\"></td><tr><td style=\"text-align:left\"></td><td>(1)</td><td>(2)</td></tr>\n",
        "<tr><td colspan=\"3\" style=\"border-bottom: 1px solid black\"></td></tr>\n",
        "\n",
-       "<tr><td style=\"text-align:left\">ABP</td><td>416.673<sup>***</sup></td><td>397.581<sup>***</sup></td></tr>\n",
-       "<tr><td style=\"text-align:left\"></td><td>(69.495)</td><td>(70.870)</td></tr>\n",
        "<tr><td style=\"text-align:left\">Age</td><td>37.241<sup></sup></td><td>24.703<sup></sup></td></tr>\n",
        "<tr><td style=\"text-align:left\"></td><td>(64.117)</td><td>(65.411)</td></tr>\n",
+       "<tr><td style=\"text-align:left\">Sex</td><td>-106.576<sup>*</sup></td><td>-82.862<sup></sup></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td>(62.125)</td><td>(64.851)</td></tr>\n",
        "<tr><td style=\"text-align:left\">BMI</td><td>787.182<sup>***</sup></td><td>789.744<sup>***</sup></td></tr>\n",
        "<tr><td style=\"text-align:left\"></td><td>(65.424)</td><td>(66.887)</td></tr>\n",
+       "<tr><td style=\"text-align:left\">ABP</td><td>416.673<sup>***</sup></td><td>397.581<sup>***</sup></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td>(69.495)</td><td>(70.870)</td></tr>\n",
        "<tr><td style=\"text-align:left\">S1</td><td></td><td>197.848<sup></sup></td></tr>\n",
        "<tr><td style=\"text-align:left\"></td><td></td><td>(143.812)</td></tr>\n",
        "<tr><td style=\"text-align:left\">S2</td><td></td><td>-169.243<sup></sup></td></tr>\n",
        "<tr><td style=\"text-align:left\"></td><td></td><td>(142.744)</td></tr>\n",
-       "<tr><td style=\"text-align:left\">Sex</td><td>-106.576<sup>*</sup></td><td>-82.862<sup></sup></td></tr>\n",
-       "<tr><td style=\"text-align:left\"></td><td>(62.125)</td><td>(64.851)</td></tr>\n",
        "<tr><td style=\"text-align:left\">const</td><td>152.133<sup>***</sup></td><td>152.133<sup>***</sup></td></tr>\n",
        "<tr><td style=\"text-align:left\"></td><td>(2.853)</td><td>(2.853)</td></tr>\n",
        "\n",
@@ -180,10 +180,10 @@
        "<tr><td colspan=\"3\" style=\"border-bottom: 1px solid black\"></td></tr><tr><td style=\"text-align: left\">Note:</td><td colspan=\"2\" style=\"text-align: right\"><sup>*</sup>p&lt;0.1; <sup>**</sup>p&lt;0.05; <sup>***</sup>p&lt;0.01</td></tr></table>"
       ],
       "text/plain": [
-       "<stargazer.stargazer.Stargazer at 0x7fc74103eb50>"
+       "<stargazer.stargazer.Stargazer at 0x14e70e74910>"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -202,7 +202,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -212,18 +212,18 @@
        "<tr><td style=\"text-align:left\"></td><td colspan=\"2\"><em>Dependent variable: target</em></td></tr><tr><td style=\"text-align:left\"></td><tr><td></td><td colspan=\"1\">Model 1</td><td colspan=\"1\">Model 2</td></tr><tr><td style=\"text-align:left\"></td><td>(1)</td><td>(2)</td></tr>\n",
        "<tr><td colspan=\"3\" style=\"border-bottom: 1px solid black\"></td></tr>\n",
        "\n",
-       "<tr><td style=\"text-align:left\">ABP</td><td>416.673<sup>***</sup></td><td>397.581<sup>***</sup></td></tr>\n",
-       "<tr><td style=\"text-align:left\"></td><td>(69.495)</td><td>(70.870)</td></tr>\n",
        "<tr><td style=\"text-align:left\">Age</td><td>37.241<sup></sup></td><td>24.703<sup></sup></td></tr>\n",
        "<tr><td style=\"text-align:left\"></td><td>(64.117)</td><td>(65.411)</td></tr>\n",
+       "<tr><td style=\"text-align:left\">Sex</td><td>-106.576<sup>*</sup></td><td>-82.862<sup></sup></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td>(62.125)</td><td>(64.851)</td></tr>\n",
        "<tr><td style=\"text-align:left\">BMI</td><td>787.182<sup>***</sup></td><td>789.744<sup>***</sup></td></tr>\n",
        "<tr><td style=\"text-align:left\"></td><td>(65.424)</td><td>(66.887)</td></tr>\n",
+       "<tr><td style=\"text-align:left\">ABP</td><td>416.673<sup>***</sup></td><td>397.581<sup>***</sup></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td>(69.495)</td><td>(70.870)</td></tr>\n",
        "<tr><td style=\"text-align:left\">S1</td><td></td><td>197.848<sup></sup></td></tr>\n",
        "<tr><td style=\"text-align:left\"></td><td></td><td>(143.812)</td></tr>\n",
        "<tr><td style=\"text-align:left\">S2</td><td></td><td>-169.243<sup></sup></td></tr>\n",
        "<tr><td style=\"text-align:left\"></td><td></td><td>(142.744)</td></tr>\n",
-       "<tr><td style=\"text-align:left\">Sex</td><td>-106.576<sup>*</sup></td><td>-82.862<sup></sup></td></tr>\n",
-       "<tr><td style=\"text-align:left\"></td><td>(62.125)</td><td>(64.851)</td></tr>\n",
        "<tr><td style=\"text-align:left\">const</td><td>152.133<sup>***</sup></td><td>152.133<sup>***</sup></td></tr>\n",
        "<tr><td style=\"text-align:left\"></td><td>(2.853)</td><td>(2.853)</td></tr>\n",
        "\n",
@@ -232,10 +232,10 @@
        "<tr><td colspan=\"3\" style=\"border-bottom: 1px solid black\"></td></tr><tr><td style=\"text-align: left\">Note:</td><td colspan=\"2\" style=\"text-align: right\"><sup>*</sup>p&lt;0.1; <sup>**</sup>p&lt;0.05; <sup>***</sup>p&lt;0.01</td></tr></table>"
       ],
       "text/plain": [
-       "<stargazer.stargazer.Stargazer at 0x7fc74103eb50>"
+       "<stargazer.stargazer.Stargazer at 0x14e70e74910>"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -247,7 +247,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -257,18 +257,18 @@
        "<tr><td style=\"text-align:left\"></td><td colspan=\"2\"><em>Dependent variable: target</em></td></tr><tr><td style=\"text-align:left\"></td><td colspan=\"2\">Test model name</td></tr><tr><td style=\"text-align:left\"></td><td>(1)</td><td>(2)</td></tr>\n",
        "<tr><td colspan=\"3\" style=\"border-bottom: 1px solid black\"></td></tr>\n",
        "\n",
-       "<tr><td style=\"text-align:left\">ABP</td><td>416.673<sup>***</sup></td><td>397.581<sup>***</sup></td></tr>\n",
-       "<tr><td style=\"text-align:left\"></td><td>(69.495)</td><td>(70.870)</td></tr>\n",
        "<tr><td style=\"text-align:left\">Age</td><td>37.241<sup></sup></td><td>24.703<sup></sup></td></tr>\n",
        "<tr><td style=\"text-align:left\"></td><td>(64.117)</td><td>(65.411)</td></tr>\n",
+       "<tr><td style=\"text-align:left\">Sex</td><td>-106.576<sup>*</sup></td><td>-82.862<sup></sup></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td>(62.125)</td><td>(64.851)</td></tr>\n",
        "<tr><td style=\"text-align:left\">BMI</td><td>787.182<sup>***</sup></td><td>789.744<sup>***</sup></td></tr>\n",
        "<tr><td style=\"text-align:left\"></td><td>(65.424)</td><td>(66.887)</td></tr>\n",
+       "<tr><td style=\"text-align:left\">ABP</td><td>416.673<sup>***</sup></td><td>397.581<sup>***</sup></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td>(69.495)</td><td>(70.870)</td></tr>\n",
        "<tr><td style=\"text-align:left\">S1</td><td></td><td>197.848<sup></sup></td></tr>\n",
        "<tr><td style=\"text-align:left\"></td><td></td><td>(143.812)</td></tr>\n",
        "<tr><td style=\"text-align:left\">S2</td><td></td><td>-169.243<sup></sup></td></tr>\n",
        "<tr><td style=\"text-align:left\"></td><td></td><td>(142.744)</td></tr>\n",
-       "<tr><td style=\"text-align:left\">Sex</td><td>-106.576<sup>*</sup></td><td>-82.862<sup></sup></td></tr>\n",
-       "<tr><td style=\"text-align:left\"></td><td>(62.125)</td><td>(64.851)</td></tr>\n",
        "<tr><td style=\"text-align:left\">const</td><td>152.133<sup>***</sup></td><td>152.133<sup>***</sup></td></tr>\n",
        "<tr><td style=\"text-align:left\"></td><td>(2.853)</td><td>(2.853)</td></tr>\n",
        "\n",
@@ -277,10 +277,10 @@
        "<tr><td colspan=\"3\" style=\"border-bottom: 1px solid black\"></td></tr><tr><td style=\"text-align: left\">Note:</td><td colspan=\"2\" style=\"text-align: right\"><sup>*</sup>p&lt;0.1; <sup>**</sup>p&lt;0.05; <sup>***</sup>p&lt;0.01</td></tr></table>"
       ],
       "text/plain": [
-       "<stargazer.stargazer.Stargazer at 0x7fc74103eb50>"
+       "<stargazer.stargazer.Stargazer at 0x14e70e74910>"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -299,7 +299,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -309,18 +309,18 @@
        "<tr><td style=\"text-align:left\"></td><td colspan=\"2\"><em>Dependent variable: target</em></td></tr><tr><td style=\"text-align:left\"></td><td colspan=\"2\">Test model name</td></tr>\n",
        "<tr><td colspan=\"3\" style=\"border-bottom: 1px solid black\"></td></tr>\n",
        "\n",
-       "<tr><td style=\"text-align:left\">ABP</td><td>416.673<sup>***</sup></td><td>397.581<sup>***</sup></td></tr>\n",
-       "<tr><td style=\"text-align:left\"></td><td>(69.495)</td><td>(70.870)</td></tr>\n",
        "<tr><td style=\"text-align:left\">Age</td><td>37.241<sup></sup></td><td>24.703<sup></sup></td></tr>\n",
        "<tr><td style=\"text-align:left\"></td><td>(64.117)</td><td>(65.411)</td></tr>\n",
+       "<tr><td style=\"text-align:left\">Sex</td><td>-106.576<sup>*</sup></td><td>-82.862<sup></sup></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td>(62.125)</td><td>(64.851)</td></tr>\n",
        "<tr><td style=\"text-align:left\">BMI</td><td>787.182<sup>***</sup></td><td>789.744<sup>***</sup></td></tr>\n",
        "<tr><td style=\"text-align:left\"></td><td>(65.424)</td><td>(66.887)</td></tr>\n",
+       "<tr><td style=\"text-align:left\">ABP</td><td>416.673<sup>***</sup></td><td>397.581<sup>***</sup></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td>(69.495)</td><td>(70.870)</td></tr>\n",
        "<tr><td style=\"text-align:left\">S1</td><td></td><td>197.848<sup></sup></td></tr>\n",
        "<tr><td style=\"text-align:left\"></td><td></td><td>(143.812)</td></tr>\n",
        "<tr><td style=\"text-align:left\">S2</td><td></td><td>-169.243<sup></sup></td></tr>\n",
        "<tr><td style=\"text-align:left\"></td><td></td><td>(142.744)</td></tr>\n",
-       "<tr><td style=\"text-align:left\">Sex</td><td>-106.576<sup>*</sup></td><td>-82.862<sup></sup></td></tr>\n",
-       "<tr><td style=\"text-align:left\"></td><td>(62.125)</td><td>(64.851)</td></tr>\n",
        "<tr><td style=\"text-align:left\">const</td><td>152.133<sup>***</sup></td><td>152.133<sup>***</sup></td></tr>\n",
        "<tr><td style=\"text-align:left\"></td><td>(2.853)</td><td>(2.853)</td></tr>\n",
        "\n",
@@ -329,10 +329,10 @@
        "<tr><td colspan=\"3\" style=\"border-bottom: 1px solid black\"></td></tr><tr><td style=\"text-align: left\">Note:</td><td colspan=\"2\" style=\"text-align: right\"><sup>*</sup>p&lt;0.1; <sup>**</sup>p&lt;0.05; <sup>***</sup>p&lt;0.01</td></tr></table>"
       ],
       "text/plain": [
-       "<stargazer.stargazer.Stargazer at 0x7fc74103eb50>"
+       "<stargazer.stargazer.Stargazer at 0x14e70e74910>"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -351,7 +351,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -361,18 +361,18 @@
        "<tr><td style=\"text-align:left\"></td><td colspan=\"2\"><em>Dependent variable: target</em></td></tr><tr><td style=\"text-align:left\"></td><td colspan=\"2\">Test model name</td></tr>\n",
        "<tr><td colspan=\"3\" style=\"border-bottom: 1px solid black\"></td></tr>\n",
        "\n",
-       "<tr><td style=\"text-align:left\">ABP</td><td>416.67<sup>***</sup></td><td>397.58<sup>***</sup></td></tr>\n",
-       "<tr><td style=\"text-align:left\"></td><td>(69.49)</td><td>(70.87)</td></tr>\n",
        "<tr><td style=\"text-align:left\">Age</td><td>37.24<sup></sup></td><td>24.70<sup></sup></td></tr>\n",
        "<tr><td style=\"text-align:left\"></td><td>(64.12)</td><td>(65.41)</td></tr>\n",
+       "<tr><td style=\"text-align:left\">Sex</td><td>-106.58<sup>*</sup></td><td>-82.86<sup></sup></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td>(62.13)</td><td>(64.85)</td></tr>\n",
        "<tr><td style=\"text-align:left\">BMI</td><td>787.18<sup>***</sup></td><td>789.74<sup>***</sup></td></tr>\n",
        "<tr><td style=\"text-align:left\"></td><td>(65.42)</td><td>(66.89)</td></tr>\n",
+       "<tr><td style=\"text-align:left\">ABP</td><td>416.67<sup>***</sup></td><td>397.58<sup>***</sup></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td>(69.49)</td><td>(70.87)</td></tr>\n",
        "<tr><td style=\"text-align:left\">S1</td><td></td><td>197.85<sup></sup></td></tr>\n",
        "<tr><td style=\"text-align:left\"></td><td></td><td>(143.81)</td></tr>\n",
        "<tr><td style=\"text-align:left\">S2</td><td></td><td>-169.24<sup></sup></td></tr>\n",
        "<tr><td style=\"text-align:left\"></td><td></td><td>(142.74)</td></tr>\n",
-       "<tr><td style=\"text-align:left\">Sex</td><td>-106.58<sup>*</sup></td><td>-82.86<sup></sup></td></tr>\n",
-       "<tr><td style=\"text-align:left\"></td><td>(62.13)</td><td>(64.85)</td></tr>\n",
        "<tr><td style=\"text-align:left\">const</td><td>152.13<sup>***</sup></td><td>152.13<sup>***</sup></td></tr>\n",
        "<tr><td style=\"text-align:left\"></td><td>(2.85)</td><td>(2.85)</td></tr>\n",
        "\n",
@@ -381,10 +381,10 @@
        "<tr><td colspan=\"3\" style=\"border-bottom: 1px solid black\"></td></tr><tr><td style=\"text-align: left\">Note:</td><td colspan=\"2\" style=\"text-align: right\"><sup>*</sup>p&lt;0.1; <sup>**</sup>p&lt;0.05; <sup>***</sup>p&lt;0.01</td></tr></table>"
       ],
       "text/plain": [
-       "<stargazer.stargazer.Stargazer at 0x7fc74103eb50>"
+       "<stargazer.stargazer.Stargazer at 0x14e70e74910>"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -403,7 +403,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -413,18 +413,18 @@
        "<tr><td style=\"text-align:left\"></td><td colspan=\"2\"><em>Dependent variable: target</em></td></tr><tr><td style=\"text-align:left\"></td><td colspan=\"2\">Test model name</td></tr>\n",
        "<tr><td colspan=\"3\" style=\"border-bottom: 1px solid black\"></td></tr>\n",
        "\n",
-       "<tr><td style=\"text-align:left\">ABP</td><td>416.67<sup>***</sup></td><td>397.58<sup>***</sup></td></tr>\n",
-       "<tr><td style=\"text-align:left\"></td><td>(280.09 , 553.26)</td><td>(258.29 , 536.87)</td></tr>\n",
        "<tr><td style=\"text-align:left\">Age</td><td>37.24<sup></sup></td><td>24.70<sup></sup></td></tr>\n",
        "<tr><td style=\"text-align:left\"></td><td>(-88.78 , 163.26)</td><td>(-103.86 , 153.26)</td></tr>\n",
+       "<tr><td style=\"text-align:left\">Sex</td><td>-106.58<sup>*</sup></td><td>-82.86<sup></sup></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td>(-228.68 , 15.52)</td><td>(-210.32 , 44.60)</td></tr>\n",
        "<tr><td style=\"text-align:left\">BMI</td><td>787.18<sup>***</sup></td><td>789.74<sup>***</sup></td></tr>\n",
        "<tr><td style=\"text-align:left\"></td><td>(658.60 , 915.77)</td><td>(658.28 , 921.20)</td></tr>\n",
+       "<tr><td style=\"text-align:left\">ABP</td><td>416.67<sup>***</sup></td><td>397.58<sup>***</sup></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td>(280.09 , 553.26)</td><td>(258.29 , 536.87)</td></tr>\n",
        "<tr><td style=\"text-align:left\">S1</td><td></td><td>197.85<sup></sup></td></tr>\n",
        "<tr><td style=\"text-align:left\"></td><td></td><td>(-84.81 , 480.50)</td></tr>\n",
        "<tr><td style=\"text-align:left\">S2</td><td></td><td>-169.24<sup></sup></td></tr>\n",
        "<tr><td style=\"text-align:left\"></td><td></td><td>(-449.80 , 111.31)</td></tr>\n",
-       "<tr><td style=\"text-align:left\">Sex</td><td>-106.58<sup>*</sup></td><td>-82.86<sup></sup></td></tr>\n",
-       "<tr><td style=\"text-align:left\"></td><td>(-228.68 , 15.52)</td><td>(-210.32 , 44.60)</td></tr>\n",
        "<tr><td style=\"text-align:left\">const</td><td>152.13<sup>***</sup></td><td>152.13<sup>***</sup></td></tr>\n",
        "<tr><td style=\"text-align:left\"></td><td>(146.53 , 157.74)</td><td>(146.53 , 157.74)</td></tr>\n",
        "\n",
@@ -433,10 +433,10 @@
        "<tr><td colspan=\"3\" style=\"border-bottom: 1px solid black\"></td></tr><tr><td style=\"text-align: left\">Note:</td><td colspan=\"2\" style=\"text-align: right\"><sup>*</sup>p&lt;0.1; <sup>**</sup>p&lt;0.05; <sup>***</sup>p&lt;0.01</td></tr></table>"
       ],
       "text/plain": [
-       "<stargazer.stargazer.Stargazer at 0x7fc74103eb50>"
+       "<stargazer.stargazer.Stargazer at 0x14e70e74910>"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -455,7 +455,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -479,10 +479,10 @@
        "<tr><td colspan=\"3\" style=\"border-bottom: 1px solid black\"></td></tr><tr><td style=\"text-align: left\">Note:</td><td colspan=\"2\" style=\"text-align: right\"><sup>*</sup>p&lt;0.1; <sup>**</sup>p&lt;0.05; <sup>***</sup>p&lt;0.01</td></tr></table>"
       ],
       "text/plain": [
-       "<stargazer.stargazer.Stargazer at 0x7fc74103eb50>"
+       "<stargazer.stargazer.Stargazer at 0x14e70e74910>"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -501,7 +501,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -525,10 +525,10 @@
        "<tr><td colspan=\"3\" style=\"border-bottom: 1px solid black\"></td></tr><tr><td style=\"text-align: left\">Note:</td><td colspan=\"2\" style=\"text-align: right\"><sup>*</sup>p&lt;0.1; <sup>**</sup>p&lt;0.05; <sup>***</sup>p&lt;0.01</td></tr></table>"
       ],
       "text/plain": [
-       "<stargazer.stargazer.Stargazer at 0x7fc74103eb50>"
+       "<stargazer.stargazer.Stargazer at 0x14e70e74910>"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -547,7 +547,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
@@ -571,10 +571,10 @@
        "<tr><td colspan=\"3\" style=\"border-bottom: 1px solid black\"></td></tr><tr><td style=\"text-align: left\">Note:</td><td colspan=\"2\" style=\"text-align: right\"><sup>*</sup>p&lt;0.1; <sup>**</sup>p&lt;0.05; <sup>***</sup>p&lt;0.01</td></tr></table>"
       ],
       "text/plain": [
-       "<stargazer.stargazer.Stargazer at 0x7fc74103eb50>"
+       "<stargazer.stargazer.Stargazer at 0x14e70e74910>"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -594,61 +594,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
     "from stargazer.stargazer import Label"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 15,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "Diabetes Study<br><table style=\"text-align:center\"><tr><td colspan=\"3\" style=\"border-bottom: 1px solid black\"></td></tr>\n",
-       "<tr><td style=\"text-align:left\"></td><td colspan=\"2\"><em>Dependent variable: target</em></td></tr><tr><td style=\"text-align:left\"></td><td colspan=\"2\">Test model name</td></tr>\n",
-       "<tr><td colspan=\"3\" style=\"border-bottom: 1px solid black\"></td></tr>\n",
-       "\n",
-       "<tr><td style=\"text-align:left\">BMI</td><td>787.18<sup>***</sup></td><td>789.74<sup>***</sup></td></tr>\n",
-       "<tr><td style=\"text-align:left\"></td><td>(658.60 , 915.77)</td><td>(658.28 , 921.20)</td></tr>\n",
-       "<tr><td style=\"text-align:left\">Age</td><td>37.24<sup></sup></td><td>24.70<sup></sup></td></tr>\n",
-       "<tr><td style=\"text-align:left\"></td><td>(-88.78 , 163.26)</td><td>(-103.86 , 153.26)</td></tr>\n",
-       "<tr><td style=\"text-align:left\">S<sub>1</sub></td><td></td><td>197.85<sup></sup></td></tr>\n",
-       "<tr><td style=\"text-align:left\"></td><td></td><td>(-84.81 , 480.50)</td></tr>\n",
-       "<tr><td style=\"text-align:left\">Sex</td><td>-106.58<sup>*</sup></td><td>-82.86<sup></sup></td></tr>\n",
-       "<tr><td style=\"text-align:left\"></td><td>(-228.68 , 15.52)</td><td>(-210.32 , 44.60)</td></tr>\n",
-       "\n",
-       "<td colspan=\"3\" style=\"border-bottom: 1px solid black\"></td></tr>\n",
-       "<tr><td style=\"text-align: left\">Observations</td><td>442</td><td>442</td></tr><tr><td style=\"text-align: left\">R<sup>2</sup></td><td>0.40</td><td>0.40</td></tr><tr><td style=\"text-align: left\">Adjusted R<sup>2</sup></td><td>0.39</td><td>0.39</td></tr><tr><td style=\"text-align: left\">Residual Std. Error</td><td>59.98 (df=437)</td><td>59.98 (df=435)</td></tr><tr><td style=\"text-align: left\">F Statistic</td><td>72.91<sup>***</sup> (df=4; 437)</td><td>48.91<sup>***</sup> (df=6; 435)</td></tr>\n",
-       "<tr><td colspan=\"3\" style=\"border-bottom: 1px solid black\"></td></tr><tr><td style=\"text-align: left\">Note:</td><td colspan=\"2\" style=\"text-align: right\"><sup>*</sup>p&lt;0.1; <sup>**</sup>p&lt;0.05; <sup>***</sup>p&lt;0.01</td></tr></table>"
-      ],
-      "text/plain": [
-       "<stargazer.stargazer.Stargazer at 0x7fc74103eb50>"
-      ]
-     },
-     "execution_count": 15,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "stargazer.rename_covariates({\n",
-    "                             'S1' : Label({'html' : 'S<sub>1</sub>',\n",
-    "                                           'LaTeX' : 'S_1'})\n",
-    "                            }\n",
-    "                           )\n",
-    "stargazer"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Hide/Show Degrees of Freedom"
    ]
   },
   {
@@ -673,14 +623,124 @@
        "<tr><td style=\"text-align:left\"></td><td>(-228.68 , 15.52)</td><td>(-210.32 , 44.60)</td></tr>\n",
        "\n",
        "<td colspan=\"3\" style=\"border-bottom: 1px solid black\"></td></tr>\n",
+       "<tr><td style=\"text-align: left\">Observations</td><td>442</td><td>442</td></tr><tr><td style=\"text-align: left\">R<sup>2</sup></td><td>0.40</td><td>0.40</td></tr><tr><td style=\"text-align: left\">Adjusted R<sup>2</sup></td><td>0.39</td><td>0.39</td></tr><tr><td style=\"text-align: left\">Residual Std. Error</td><td>59.98 (df=437)</td><td>59.98 (df=435)</td></tr><tr><td style=\"text-align: left\">F Statistic</td><td>72.91<sup>***</sup> (df=4; 437)</td><td>48.91<sup>***</sup> (df=6; 435)</td></tr>\n",
+       "<tr><td colspan=\"3\" style=\"border-bottom: 1px solid black\"></td></tr><tr><td style=\"text-align: left\">Note:</td><td colspan=\"2\" style=\"text-align: right\"><sup>*</sup>p&lt;0.1; <sup>**</sup>p&lt;0.05; <sup>***</sup>p&lt;0.01</td></tr></table>"
+      ],
+      "text/plain": [
+       "<stargazer.stargazer.Stargazer at 0x14e70e74910>"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "stargazer.rename_covariates({\n",
+    "                             'S1' : Label({'html' : 'S<sub>1</sub>',\n",
+    "                                           'LaTeX' : 'S_1'})\n",
+    "                            }\n",
+    "                           )\n",
+    "stargazer"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "... also rename interaction terms automatically when using formulas"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table style=\"text-align:center\"><tr><td colspan=\"3\" style=\"border-bottom: 1px solid black\"></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td colspan=\"2\"><em>Dependent variable: target</em></td></tr><tr><td style=\"text-align:left\"></td><tr><td style=\"text-align:left\"></td><td>(1)</td><td>(2)</td></tr>\n",
+       "<tr><td colspan=\"3\" style=\"border-bottom: 1px solid black\"></td></tr>\n",
+       "\n",
+       "<tr><td style=\"text-align:left\">Age</td><td>52.452<sup></sup></td><td>56.917<sup></sup></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td>(64.228)</td><td>(63.702)</td></tr>\n",
+       "<tr><td style=\"text-align:left\">Body Mass Index</td><td>813.161<sup>***</sup></td><td>818.959<sup>***</sup></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td>(66.233)</td><td>(66.073)</td></tr>\n",
+       "<tr><td style=\"text-align:left\">Age &#215; Body Mass Index</td><td>2809.479<sup>**</sup></td><td>2486.949<sup>*</sup></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td>(1291.944)</td><td>(1294.873)</td></tr>\n",
+       "<tr><td style=\"text-align:left\">Female</td><td>-102.705<sup>*</sup></td><td>-120.044<sup>*</sup></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td>(61.887)</td><td>(62.208)</td></tr>\n",
+       "<tr><td style=\"text-align:left\">ABP</td><td>413.120<sup>***</sup></td><td>417.803<sup>***</sup></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td>(69.219)</td><td>(68.816)</td></tr>\n",
+       "<tr><td style=\"text-align:left\">Age &#215; Female</td><td></td><td>3384.230<sup>***</sup></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td></td><td>(1294.381)</td></tr>\n",
+       "<tr><td style=\"text-align:left\">Body Mass Index &#215; Female</td><td></td><td>2280.831<sup>*</sup></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td></td><td>(1303.691)</td></tr>\n",
+       "<tr><td style=\"text-align:left\">Age &#215; Body Mass Index &#215; Female</td><td></td><td>23021.023<sup></sup></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td></td><td>(27374.170)</td></tr>\n",
+       "<tr><td style=\"text-align:left\">Intercept</td><td>150.957<sup>***</sup></td><td>149.454<sup>***</sup></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td>(2.892)</td><td>(2.905)</td></tr>\n",
+       "\n",
+       "<td colspan=\"3\" style=\"border-bottom: 1px solid black\"></td></tr>\n",
+       "<tr><td style=\"text-align: left\">Observations</td><td>442</td><td>442</td></tr><tr><td style=\"text-align: left\">R<sup>2</sup></td><td>0.407</td><td>0.422</td></tr><tr><td style=\"text-align: left\">Adjusted R<sup>2</sup></td><td>0.400</td><td>0.411</td></tr><tr><td style=\"text-align: left\">Residual Std. Error</td><td>59.721 (df=436)</td><td>59.147 (df=433)</td></tr><tr><td style=\"text-align: left\">F Statistic</td><td>59.774<sup>***</sup> (df=5; 436)</td><td>39.525<sup>***</sup> (df=8; 433)</td></tr>\n",
+       "<tr><td colspan=\"3\" style=\"border-bottom: 1px solid black\"></td></tr><tr><td style=\"text-align: left\">Note:</td><td colspan=\"2\" style=\"text-align: right\"><sup>*</sup>p&lt;0.1; <sup>**</sup>p&lt;0.05; <sup>***</sup>p&lt;0.01</td></tr></table>"
+      ],
+      "text/plain": [
+       "<stargazer.stargazer.Stargazer at 0x14e76496880>"
+      ]
+     },
+     "execution_count": 35,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "estint1=sm.OLS.from_formula('target ~ Age * BMI + Sex + ABP', data=df).fit()\n",
+    "estint2=sm.OLS.from_formula('target ~ Age * BMI * Sex + ABP', data=df).fit()\n",
+    "tabInt= Stargazer([estint1,estint2])\n",
+    "tabInt.rename_covariates({\"BMI\":\"Body Mass Index\",\n",
+    "                          'Sex':\"Female\"}, formula=True)\n",
+    "tabInt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Hide/Show Degrees of Freedom"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "Diabetes Study<br><table style=\"text-align:center\"><tr><td colspan=\"3\" style=\"border-bottom: 1px solid black\"></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td colspan=\"2\"><em>Dependent variable: target</em></td></tr><tr><td style=\"text-align:left\"></td><td colspan=\"2\">Test model name</td></tr>\n",
+       "<tr><td colspan=\"3\" style=\"border-bottom: 1px solid black\"></td></tr>\n",
+       "\n",
+       "<tr><td style=\"text-align:left\">BMI</td><td>787.18<sup>***</sup></td><td>789.74<sup>***</sup></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td>(658.60 , 915.77)</td><td>(658.28 , 921.20)</td></tr>\n",
+       "<tr><td style=\"text-align:left\">Age</td><td>37.24<sup></sup></td><td>24.70<sup></sup></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td>(-88.78 , 163.26)</td><td>(-103.86 , 153.26)</td></tr>\n",
+       "<tr><td style=\"text-align:left\">S<sub>1</sub></td><td></td><td>197.85<sup></sup></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td></td><td>(-84.81 , 480.50)</td></tr>\n",
+       "<tr><td style=\"text-align:left\">Sex</td><td>-106.58<sup>*</sup></td><td>-82.86<sup></sup></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td>(-228.68 , 15.52)</td><td>(-210.32 , 44.60)</td></tr>\n",
+       "\n",
+       "<td colspan=\"3\" style=\"border-bottom: 1px solid black\"></td></tr>\n",
        "<tr><td style=\"text-align: left\">Observations</td><td>442</td><td>442</td></tr><tr><td style=\"text-align: left\">R<sup>2</sup></td><td>0.40</td><td>0.40</td></tr><tr><td style=\"text-align: left\">Adjusted R<sup>2</sup></td><td>0.39</td><td>0.39</td></tr><tr><td style=\"text-align: left\">Residual Std. Error</td><td>59.98</td><td>59.98</td></tr><tr><td style=\"text-align: left\">F Statistic</td><td>72.91<sup>***</sup></td><td>48.91<sup>***</sup></td></tr>\n",
        "<tr><td colspan=\"3\" style=\"border-bottom: 1px solid black\"></td></tr><tr><td style=\"text-align: left\">Note:</td><td colspan=\"2\" style=\"text-align: right\"><sup>*</sup>p&lt;0.1; <sup>**</sup>p&lt;0.05; <sup>***</sup>p&lt;0.01</td></tr></table>"
       ],
       "text/plain": [
-       "<stargazer.stargazer.Stargazer at 0x7fc74103eb50>"
+       "<stargazer.stargazer.Stargazer at 0x14e70e74910>"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -699,7 +759,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 18,
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
@@ -727,10 +787,10 @@
        "<tr><td colspan=\"3\" style=\"border-bottom: 1px solid black\"></td></tr><tr><td style=\"text-align: left\">Note:</td><td colspan=\"2\" style=\"text-align: right\"><sup>*</sup>p&lt;0.1; <sup>**</sup>p&lt;0.05; <sup>***</sup>p&lt;0.01</td></tr><tr><td colspan=\"3\" style=\"text-align: right\">First note</td></tr><tr><td colspan=\"3\" style=\"text-align: right\">Second note</td></tr></table>"
       ],
       "text/plain": [
-       "<stargazer.stargazer.Stargazer at 0x7fc74103eb50>"
+       "<stargazer.stargazer.Stargazer at 0x14e70e74910>"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -749,7 +809,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
@@ -773,10 +833,10 @@
        "<tr><td style=\"text-align: left\">Largest R<sup>2</sup></td><td>Yes</td><td>Yes</td></tr><tr><td colspan=\"3\" style=\"border-bottom: 1px solid black\"></td></tr><tr><td style=\"text-align: left\">Note:</td><td colspan=\"2\" style=\"text-align: right\"><sup>*</sup>p&lt;0.1; <sup>**</sup>p&lt;0.05; <sup>***</sup>p&lt;0.01</td></tr><tr><td colspan=\"3\" style=\"text-align: right\">First note</td></tr><tr><td colspan=\"3\" style=\"text-align: right\">Second note</td></tr></table>"
       ],
       "text/plain": [
-       "<stargazer.stargazer.Stargazer at 0x7fc74103eb50>"
+       "<stargazer.stargazer.Stargazer at 0x14e70e74910>"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -803,7 +863,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
@@ -827,10 +887,10 @@
        "<tr><td style=\"text-align: left\">Largest R<sup>2</sup></td><td>Yes</td><td>Yes</td></tr><tr><td colspan=\"3\" style=\"border-bottom: 1px solid black\"></td></tr><tr><td style=\"text-align: left\">Note:</td><td colspan=\"2\" style=\"text-align: right\"><sup>*</sup>p&lt;0.1; <sup>**</sup>p&lt;0.07; <sup>***</sup>p&lt;0.05</td></tr><tr><td colspan=\"3\" style=\"text-align: right\">First note</td></tr><tr><td colspan=\"3\" style=\"text-align: right\">Second note</td></tr></table>"
       ],
       "text/plain": [
-       "<stargazer.stargazer.Stargazer at 0x7fc74103eb50>"
+       "<stargazer.stargazer.Stargazer at 0x14e70e74910>"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -849,7 +909,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {
@@ -873,10 +933,10 @@
        "<tr><td style=\"text-align: left\">Largest R<sup>2</sup></td><td>Yes</td><td>Yes</td></tr><tr><td colspan=\"3\" style=\"border-bottom: 1px solid black\"></td></tr><tr><td style=\"text-align: left\">Note:</td></tr><td colspan=\"3\" style=\"text-align: right\">First note</td></tr><tr><td colspan=\"3\" style=\"text-align: right\">Second note</td></tr></table>"
       ],
       "text/plain": [
-       "<stargazer.stargazer.Stargazer at 0x7fc74103eb50>"
+       "<stargazer.stargazer.Stargazer at 0x14e70e74910>"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -895,7 +955,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [
     {
@@ -919,10 +979,10 @@
        "<tr><td style=\"text-align: left\">Largest R<sup>2</sup></td><td>Yes</td><td>Yes</td></tr><tr><td colspan=\"3\" style=\"border-bottom: 1px solid black\"></td></tr><tr><td style=\"text-align: left\">Note:</td></tr><td colspan=\"3\" style=\"text-align: right\">First note</td></tr><tr><td colspan=\"3\" style=\"text-align: right\">Second note</td></tr></table>"
       ],
       "text/plain": [
-       "<stargazer.stargazer.Stargazer at 0x7fc74103eb50>"
+       "<stargazer.stargazer.Stargazer at 0x14e70e74910>"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -948,7 +1008,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
@@ -980,10 +1040,10 @@
        "<tr><td colspan=\"4\" style=\"border-bottom: 1px solid black\"></td></tr><tr><td style=\"text-align: left\">Note:</td><td colspan=\"3\" style=\"text-align: right\"><sup>*</sup>p&lt;0.1; <sup>**</sup>p&lt;0.05; <sup>***</sup>p&lt;0.01</td></tr></table>"
       ],
       "text/plain": [
-       "<stargazer.stargazer.Stargazer at 0x7fc7410831d0>"
+       "<stargazer.stargazer.Stargazer at 0x14e72f3b460>"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1030,27 +1090,27 @@
        "<tr><td style=\"text-align:left\"></td><tr><td></td><td colspan=\"1\">OLS</td><td colspan=\"1\">OLS</td><td colspan=\"1\">IV</td></tr><tr><td style=\"text-align:left\"></td><td>(1)</td><td>(2)</td><td>(3)</td></tr>\n",
        "<tr><td colspan=\"4\" style=\"border-bottom: 1px solid black\"></td></tr>\n",
        "\n",
-       "<tr><td style=\"text-align:left\">Intercept</td><td>5.861<sup>***</sup></td><td>5.861<sup>***</sup></td><td>6.771<sup>***</sup></td></tr>\n",
-       "<tr><td style=\"text-align:left\"></td><td>(0.157)</td><td>(0.157)</td><td>(0.257)</td></tr>\n",
-       "<tr><td style=\"text-align:left\">age</td><td>-0.004<sup>*</sup></td><td>-0.004<sup>*</sup></td><td>-0.013<sup>***</sup></td></tr>\n",
-       "<tr><td style=\"text-align:left\"></td><td>(0.002)</td><td>(0.002)</td><td>(0.003)</td></tr>\n",
-       "<tr><td style=\"text-align:left\">blhisp</td><td>-0.151<sup>***</sup></td><td>-0.151<sup>***</sup></td><td>-0.217<sup>***</sup></td></tr>\n",
-       "<tr><td style=\"text-align:left\"></td><td>(0.034)</td><td>(0.034)</td><td>(0.039)</td></tr>\n",
-       "<tr><td style=\"text-align:left\">female</td><td>0.058<sup>**</sup></td><td>0.058<sup>**</sup></td><td></td></tr>\n",
-       "<tr><td style=\"text-align:left\"></td><td>(0.025)</td><td>(0.025)</td><td></td></tr>\n",
-       "<tr><td style=\"text-align:left\">hi_empunion</td><td>0.074<sup>***</sup></td><td>0.074<sup>***</sup></td><td>-0.889<sup>***</sup></td></tr>\n",
-       "<tr><td style=\"text-align:left\"></td><td>(0.026)</td><td>(0.026)</td><td>(0.213)</td></tr>\n",
-       "<tr><td style=\"text-align:left\">linc</td><td>0.010<sup></sup></td><td>0.010<sup></sup></td><td>0.087<sup>***</sup></td></tr>\n",
-       "<tr><td style=\"text-align:left\"></td><td>(0.014)</td><td>(0.014)</td><td>(0.023)</td></tr>\n",
        "<tr><td style=\"text-align:left\">totchr</td><td>0.440<sup>***</sup></td><td>0.440<sup>***</sup></td><td>0.450<sup>***</sup></td></tr>\n",
        "<tr><td style=\"text-align:left\"></td><td>(0.009)</td><td>(0.009)</td><td>(0.010)</td></tr>\n",
+       "<tr><td style=\"text-align:left\">female</td><td>0.058<sup>**</sup></td><td>0.058<sup>**</sup></td><td></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td>(0.025)</td><td>(0.025)</td><td></td></tr>\n",
+       "<tr><td style=\"text-align:left\">age</td><td>-0.004<sup>*</sup></td><td>-0.004<sup>*</sup></td><td>-0.013<sup>***</sup></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td>(0.002)</td><td>(0.002)</td><td>(0.003)</td></tr>\n",
+       "<tr><td style=\"text-align:left\">linc</td><td>0.010<sup></sup></td><td>0.010<sup></sup></td><td>0.087<sup>***</sup></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td>(0.014)</td><td>(0.014)</td><td>(0.023)</td></tr>\n",
+       "<tr><td style=\"text-align:left\">blhisp</td><td>-0.151<sup>***</sup></td><td>-0.151<sup>***</sup></td><td>-0.217<sup>***</sup></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td>(0.034)</td><td>(0.034)</td><td>(0.039)</td></tr>\n",
+       "<tr><td style=\"text-align:left\">hi_empunion</td><td>0.074<sup>***</sup></td><td>0.074<sup>***</sup></td><td>-0.889<sup>***</sup></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td>(0.026)</td><td>(0.026)</td><td>(0.213)</td></tr>\n",
+       "<tr><td style=\"text-align:left\">Intercept</td><td>5.861<sup>***</sup></td><td>5.861<sup>***</sup></td><td>6.771<sup>***</sup></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td>(0.157)</td><td>(0.157)</td><td>(0.257)</td></tr>\n",
        "\n",
        "<td colspan=\"4\" style=\"border-bottom: 1px solid black\"></td></tr>\n",
        "<tr><td style=\"text-align: left\">Observations</td><td>10089</td><td>10089</td><td>10089</td></tr><tr><td style=\"text-align: left\">R<sup>2</sup></td><td>0.177</td><td>0.177</td><td>0.066</td></tr><tr><td style=\"text-align: left\">Residual Std. Error</td><td>0.573 (df=10082)</td><td>0.573 (df=10082)</td><td>0.350 (df=10083)</td></tr><tr><td style=\"text-align: left\">F Statistic</td><td>2262.644<sup>***</sup> (df=7; 10082)</td><td>2262.644<sup>***</sup> (df=7; 10082)</td><td>2004.325<sup>***</sup> (df=6; 10083)</td></tr>\n",
        "<tr><td colspan=\"4\" style=\"border-bottom: 1px solid black\"></td></tr><tr><td style=\"text-align: left\">Note:</td><td colspan=\"3\" style=\"text-align: right\"><sup>*</sup>p&lt;0.1; <sup>**</sup>p&lt;0.05; <sup>***</sup>p&lt;0.01</td></tr></table>"
       ],
       "text/plain": [
-       "<stargazer.stargazer.Stargazer at 0x7fc7408da550>"
+       "<stargazer.stargazer.Stargazer at 0x14e75fb1310>"
       ]
      },
      "execution_count": 24,
@@ -1101,7 +1161,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.2"
+   "version": "3.9.13"
   }
  },
  "nbformat": 4,

--- a/stargazer/stargazer.py
+++ b/stargazer/stargazer.py
@@ -151,7 +151,12 @@ class Stargazer:
         covs = []
         for md in self.model_data:
             covs = covs + list(md['cov_names'])
-        self.cov_names = sorted(set(covs))
+        # Drop duplicates but keep order of first appearance
+        self.cov_names = []
+        [self.cov_names.append(x) for x in covs if x not in self.cov_names]
+        #  Move constant/Intercept to the end of the list 
+        const = ['Intercept', 'const']
+        self.cov_names = [x for x in self.cov_names if x not in const] + [x for x in self.cov_names if x in const]
 
         self.validate_input()
 

--- a/stargazer/stargazer.py
+++ b/stargazer/stargazer.py
@@ -255,8 +255,22 @@ class Stargazer:
         self.original_cov_names = self.cov_names
         self.cov_names = cov_names
 
-    def rename_covariates(self, cov_map):
+    def rename_covariates(self, cov_map, 
+                          formula=False, 
+                          interaction = Label({'html' : ' &#215; ', 'LaTeX' : ' $\\times$ '})):
+        
+        def _formatInteraction(cov, fmt):
+            with Label.context(fmt):
+                return interaction.join([str(cov_map.get(k, k)) for k in cov.split(":")])
+
         if hasattr(cov_map, "get"):
+            if formula:
+                # Rename interaction terms generated from formula: add respective items to the cov_map dictionary
+                # that combine the names of the interacted variables & link with interaction symbol  
+                for cov in self.cov_names:
+                    if ":" in cov:
+                        cov_map[cov]= Label({'html' : _formatInteraction(cov, 'html'),
+                                             'LaTeX' : _formatInteraction(cov, 'LaTeX')})
             self.cov_map = lambda k : cov_map.get(k, k)
         elif callable(cov_map):
             self.cov_map = cov_map


### PR DESCRIPTION
These are two potential changes:

- The first one is a small change concerning the default order of variables. Currently the variables are ordered alphabetically as after collecting the variables from different models duplicates are dropped by self.cov_names = sorted(set(covs)) which also causes the variables to be sorted alphabetically. I guess that in most cases users would prefer to keep the coefficient order given by the models as a default order so I adapted the code to drop duplicates without changing the order of coefficients. When I did that I realized that it would be convenient to always move the constant/intercept to the end of the table where it is displayed in most cases in papers.

- The second one is a small extension of the rename_covariates method. Currently users have to separately rename also interaction terms which are generated automatically when using formulas such as "y~x*z". The extension simply looks up the names of  x and z in the cov_map dictionary (when the user uses a dictionary and not a function) & names the interaction term accordingly (preserving Labels when they are used for special formatting) & allows the use to override the interaction symbol. 