### PR TITLE
Handle case of negative model_ss for IV2SLS

### DIFF
--- a/stargazer/translators/linearmodels.py
+++ b/stargazer/translators/linearmodels.py
@@ -2,7 +2,7 @@
 Compatibility layer with results from linearmodels.
 """
 
-from math import nan, sqrt
+from math import sqrt
 
 from linearmodels.iv.results import IVResults, OLSResults
 from linearmodels.panel.results import (
@@ -39,17 +39,6 @@ linear_model_map_panel = {
 linear_model_map_iv = dict()
 
 
-def handle_resid_std_err(model):
-    if isinstance(model, IVResults):
-        try:
-            resid_std_err = sqrt(model.model_ss / model.df_resid)
-        except ValueError:  # Negative model_ss IV
-            resid_std_err = nan
-    else:
-        resid_std_err = sqrt(model.model_ss / model.df_resid)
-    return resid_std_err
-
-
 def extract_model_data(model):
     data = {}
     if isinstance(model, (PanelEffectsResults, RandomEffectsResults, PanelResults)):
@@ -73,7 +62,7 @@ def extract_model_data(model):
     data["cov_names"] = model.params.index.values
     data["conf_int_low_values"] = model.conf_int().lower
     data["conf_int_high_values"] = model.conf_int().upper
-    data["resid_std_err"] = handle_resid_std_err(model)
+    data["resid_std_err"] = sqrt(model.s2)
     data["f_statistic"] = model.f_statistic.stat
     data["f_p_value"] = model.f_statistic.pval
     data["r2_adj"] = None


### PR DESCRIPTION
When using the package I got an `ValueError: math domain error` when creating a table for `IV2SLS` models.
The reason for this is that we take the `sqrt` when computing the `resid_std_error` and in my case, the model_ss was negative.
Yes, the residual sum of squares (` model_ss`) can be negative in the context of IV estimation; see [this](https://stats.stackexchange.com/a/421348/259737) great answer.
This PR creates a function that handles this case. 
However, I am not sure whether setting it to `nan` is the best solution, although at least this signals to the user that the `model_ss` is not interpretable; it should be dropped altogether for IV models.