### PR TITLE
Issue #85 fix

### DIFF
--- a/stargazer/stargazer.py
+++ b/stargazer/stargazer.py
@@ -119,6 +119,7 @@ class Stargazer:
         self.sig_levels = [0.1, 0.05, 0.01]
         self.sig_digits = 3
         self.confidence_intervals = False
+        self.T_statistic = True
         self.show_footer = True
         self.custom_lines = defaultdict(list)
         self.show_n = True
@@ -221,6 +222,10 @@ class Stargazer:
     def show_confidence_intervals(self, show):
         assert type(show) == bool, 'Please input True/False'
         self.confidence_intervals = show
+    
+    def show_T_Stat(self, show):
+        assert type(show) == bool, 'Please input True/False'
+        self.T_statistic = show
 
     def dependent_variable_name(self, name):
         assert type(name) == str, 'Please input a string to use as the depedent variable name'
@@ -543,8 +548,11 @@ class HTMLRenderer(Renderer):
                 if self.confidence_intervals:
                     cov_text += self._float_format(md['conf_int_low_values'][cov_name]) + ' , '
                     cov_text += self._float_format(md['conf_int_high_values'][cov_name])
-                else:
+                elif self.T_statistic:
                     cov_text += self._float_format(md['T_Stat'][cov_name])
+                else:
+                    cov_text += self._float_format(md['cov_std_err'][cov_name])
+
                 cov_text += ')</td>'
             else:
                 cov_text += f'<td{spacing}></td>'

--- a/stargazer/stargazer.py
+++ b/stargazer/stargazer.py
@@ -544,7 +544,7 @@ class HTMLRenderer(Renderer):
                     cov_text += self._float_format(md['conf_int_low_values'][cov_name]) + ' , '
                     cov_text += self._float_format(md['conf_int_high_values'][cov_name])
                 else:
-                    cov_text += self._float_format(md['cov_std_err'][cov_name])
+                    cov_text += self._float_format(md['T_Stat'][cov_name])
                 cov_text += ')</td>'
             else:
                 cov_text += f'<td{spacing}></td>'

--- a/stargazer/stargazer.py
+++ b/stargazer/stargazer.py
@@ -119,7 +119,7 @@ class Stargazer:
         self.sig_levels = [0.1, 0.05, 0.01]
         self.sig_digits = 3
         self.confidence_intervals = False
-        self.T_statistic = True
+        self.T_statistic = False
         self.show_footer = True
         self.custom_lines = defaultdict(list)
         self.show_n = True

--- a/stargazer/translators/linearmodels.py
+++ b/stargazer/translators/linearmodels.py
@@ -24,6 +24,7 @@ linearmodels_map_base = {
     "degree_freedom": "df_model",
     "degree_freedom_resid": "df_resid",
     "nobs": "nobs",
+    "T_Stat": "tvalues"
 }
 
 # Mapping for linearmodels key parameters

--- a/stargazer/translators/statsmodels.py
+++ b/stargazer/translators/statsmodels.py
@@ -24,7 +24,8 @@ statsmodels_map = {'p_values' : 'pvalues',
                    'degree_freedom' : 'df_model',
                    'degree_freedom_resid' : 'df_resid',
                    'nobs' : 'nobs',
-                   'f_statistic' : 'fvalue'
+                   'f_statistic' : 'fvalue',
+                   'T_Stat' : 'tvalues'
                    }
 
 def extract_model_data(model):
@@ -43,7 +44,7 @@ def extract_model_data(model):
         data['cov_names'] = model.model.data.orig_exog.columns
 
         # These are simple arrays, not Series:
-        for what in 'cov_values', 'p_values', 'cov_std_err':
+        for what in 'cov_values', 'p_values', 'cov_std_err', 'T_Stat':
             data[what] = pd.Series(data[what],
                                    index=data['cov_names'])
 

--- a/tests/feature_test.ipynb
+++ b/tests/feature_test.ipynb
@@ -1,0 +1,735 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Test Notebook for Issue #85 \"stat in parenthesis\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Starts with same examples as in examples.ipynb"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "from sklearn import datasets\n",
+    "import statsmodels.api as sm\n",
+    "from stargazer.stargazer import Stargazer, LineLocation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "diabetes = datasets.load_diabetes()\n",
+    "df = pd.DataFrame(diabetes.data)\n",
+    "df.columns = ['Age', 'Sex', 'BMI', 'ABP', 'S1', 'S2', 'S3', 'S4', 'S5', 'S6']\n",
+    "df['target'] = diabetes.target\n",
+    "\n",
+    "est = sm.OLS(endog=df['target'], exog=sm.add_constant(df[df.columns[0:4]])).fit()\n",
+    "est2 = sm.OLS(endog=df['target'], exog=sm.add_constant(df[df.columns[0:6]])).fit()\n",
+    "\n",
+    "\n",
+    "stargazer = Stargazer([est, est2])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Custom Title"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "Diabetes Study<br><table style=\"text-align:center\"><tr><td colspan=\"3\" style=\"border-bottom: 1px solid black\"></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td colspan=\"2\"><em>Dependent variable: target</em></td></tr><tr><td style=\"text-align:left\"></td><tr><td style=\"text-align:left\"></td><td>(1)</td><td>(2)</td></tr>\n",
+       "<tr><td colspan=\"3\" style=\"border-bottom: 1px solid black\"></td></tr>\n",
+       "\n",
+       "<tr><td style=\"text-align:left\">ABP</td><td>416.673<sup>***</sup></td><td>397.581<sup>***</sup></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td>(69.495)</td><td>(70.870)</td></tr>\n",
+       "<tr><td style=\"text-align:left\">Age</td><td>37.241<sup></sup></td><td>24.703<sup></sup></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td>(64.117)</td><td>(65.411)</td></tr>\n",
+       "<tr><td style=\"text-align:left\">BMI</td><td>787.182<sup>***</sup></td><td>789.744<sup>***</sup></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td>(65.424)</td><td>(66.887)</td></tr>\n",
+       "<tr><td style=\"text-align:left\">S1</td><td></td><td>197.848<sup></sup></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td></td><td>(143.812)</td></tr>\n",
+       "<tr><td style=\"text-align:left\">S2</td><td></td><td>-169.243<sup></sup></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td></td><td>(142.744)</td></tr>\n",
+       "<tr><td style=\"text-align:left\">Sex</td><td>-106.576<sup>*</sup></td><td>-82.862<sup></sup></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td>(62.125)</td><td>(64.851)</td></tr>\n",
+       "<tr><td style=\"text-align:left\">const</td><td>152.133<sup>***</sup></td><td>152.133<sup>***</sup></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td>(2.853)</td><td>(2.853)</td></tr>\n",
+       "\n",
+       "<td colspan=\"3\" style=\"border-bottom: 1px solid black\"></td></tr>\n",
+       "<tr><td style=\"text-align: left\">Observations</td><td>442</td><td>442</td></tr><tr><td style=\"text-align: left\">R<sup>2</sup></td><td>0.400</td><td>0.403</td></tr><tr><td style=\"text-align: left\">Adjusted R<sup>2</sup></td><td>0.395</td><td>0.395</td></tr><tr><td style=\"text-align: left\">Residual Std. Error</td><td>59.976 (df=437)</td><td>59.982 (df=435)</td></tr><tr><td style=\"text-align: left\">F Statistic</td><td>72.913<sup>***</sup> (df=4; 437)</td><td>48.915<sup>***</sup> (df=6; 435)</td></tr>\n",
+       "<tr><td colspan=\"3\" style=\"border-bottom: 1px solid black\"></td></tr><tr><td style=\"text-align: left\">Note:</td><td colspan=\"2\" style=\"text-align: right\"><sup>*</sup>p&lt;0.1; <sup>**</sup>p&lt;0.05; <sup>***</sup>p&lt;0.01</td></tr></table>"
+      ],
+      "text/plain": [
+       "<stargazer.stargazer.Stargazer at 0x26d69d1d190>"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "stargazer.title('Diabetes Study')\n",
+    "stargazer"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Custom Model Names"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "Diabetes Study<br><table style=\"text-align:center\"><tr><td colspan=\"3\" style=\"border-bottom: 1px solid black\"></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td colspan=\"2\"><em>Dependent variable: target</em></td></tr><tr><td style=\"text-align:left\"></td><tr><td></td><td colspan=\"1\">Model 1</td><td colspan=\"1\">Model 2</td></tr><tr><td style=\"text-align:left\"></td><td>(1)</td><td>(2)</td></tr>\n",
+       "<tr><td colspan=\"3\" style=\"border-bottom: 1px solid black\"></td></tr>\n",
+       "\n",
+       "<tr><td style=\"text-align:left\">ABP</td><td>416.673<sup>***</sup></td><td>397.581<sup>***</sup></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td>(69.495)</td><td>(70.870)</td></tr>\n",
+       "<tr><td style=\"text-align:left\">Age</td><td>37.241<sup></sup></td><td>24.703<sup></sup></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td>(64.117)</td><td>(65.411)</td></tr>\n",
+       "<tr><td style=\"text-align:left\">BMI</td><td>787.182<sup>***</sup></td><td>789.744<sup>***</sup></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td>(65.424)</td><td>(66.887)</td></tr>\n",
+       "<tr><td style=\"text-align:left\">S1</td><td></td><td>197.848<sup></sup></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td></td><td>(143.812)</td></tr>\n",
+       "<tr><td style=\"text-align:left\">S2</td><td></td><td>-169.243<sup></sup></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td></td><td>(142.744)</td></tr>\n",
+       "<tr><td style=\"text-align:left\">Sex</td><td>-106.576<sup>*</sup></td><td>-82.862<sup></sup></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td>(62.125)</td><td>(64.851)</td></tr>\n",
+       "<tr><td style=\"text-align:left\">const</td><td>152.133<sup>***</sup></td><td>152.133<sup>***</sup></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td>(2.853)</td><td>(2.853)</td></tr>\n",
+       "\n",
+       "<td colspan=\"3\" style=\"border-bottom: 1px solid black\"></td></tr>\n",
+       "<tr><td style=\"text-align: left\">Observations</td><td>442</td><td>442</td></tr><tr><td style=\"text-align: left\">R<sup>2</sup></td><td>0.400</td><td>0.403</td></tr><tr><td style=\"text-align: left\">Adjusted R<sup>2</sup></td><td>0.395</td><td>0.395</td></tr><tr><td style=\"text-align: left\">Residual Std. Error</td><td>59.976 (df=437)</td><td>59.982 (df=435)</td></tr><tr><td style=\"text-align: left\">F Statistic</td><td>72.913<sup>***</sup> (df=4; 437)</td><td>48.915<sup>***</sup> (df=6; 435)</td></tr>\n",
+       "<tr><td colspan=\"3\" style=\"border-bottom: 1px solid black\"></td></tr><tr><td style=\"text-align: left\">Note:</td><td colspan=\"2\" style=\"text-align: right\"><sup>*</sup>p&lt;0.1; <sup>**</sup>p&lt;0.05; <sup>***</sup>p&lt;0.01</td></tr></table>"
+      ],
+      "text/plain": [
+       "<stargazer.stargazer.Stargazer at 0x26d69d1d190>"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "stargazer.custom_columns(['Model 1', 'Model 2'], [1, 1])\n",
+    "stargazer"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## New Feature: Show T stat below the coefficient rather than standard error"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "Diabetes Study<br><table style=\"text-align:center\"><tr><td colspan=\"3\" style=\"border-bottom: 1px solid black\"></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td colspan=\"2\"><em>Dependent variable: target</em></td></tr><tr><td style=\"text-align:left\"></td><tr><td></td><td colspan=\"1\">Model 1</td><td colspan=\"1\">Model 2</td></tr><tr><td style=\"text-align:left\"></td><td>(1)</td><td>(2)</td></tr>\n",
+       "<tr><td colspan=\"3\" style=\"border-bottom: 1px solid black\"></td></tr>\n",
+       "\n",
+       "<tr><td style=\"text-align:left\">ABP</td><td>416.673<sup>***</sup></td><td>397.581<sup>***</sup></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td>(5.996)</td><td>(5.610)</td></tr>\n",
+       "<tr><td style=\"text-align:left\">Age</td><td>37.241<sup></sup></td><td>24.703<sup></sup></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td>(0.581)</td><td>(0.378)</td></tr>\n",
+       "<tr><td style=\"text-align:left\">BMI</td><td>787.182<sup>***</sup></td><td>789.744<sup>***</sup></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td>(12.032)</td><td>(11.807)</td></tr>\n",
+       "<tr><td style=\"text-align:left\">S1</td><td></td><td>197.848<sup></sup></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td></td><td>(1.376)</td></tr>\n",
+       "<tr><td style=\"text-align:left\">S2</td><td></td><td>-169.243<sup></sup></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td></td><td>(-1.186)</td></tr>\n",
+       "<tr><td style=\"text-align:left\">Sex</td><td>-106.576<sup>*</sup></td><td>-82.862<sup></sup></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td>(-1.716)</td><td>(-1.278)</td></tr>\n",
+       "<tr><td style=\"text-align:left\">const</td><td>152.133<sup>***</sup></td><td>152.133<sup>***</sup></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td>(53.329)</td><td>(53.323)</td></tr>\n",
+       "\n",
+       "<td colspan=\"3\" style=\"border-bottom: 1px solid black\"></td></tr>\n",
+       "<tr><td style=\"text-align: left\">Observations</td><td>442</td><td>442</td></tr><tr><td style=\"text-align: left\">R<sup>2</sup></td><td>0.400</td><td>0.403</td></tr><tr><td style=\"text-align: left\">Adjusted R<sup>2</sup></td><td>0.395</td><td>0.395</td></tr><tr><td style=\"text-align: left\">Residual Std. Error</td><td>59.976 (df=437)</td><td>59.982 (df=435)</td></tr><tr><td style=\"text-align: left\">F Statistic</td><td>72.913<sup>***</sup> (df=4; 437)</td><td>48.915<sup>***</sup> (df=6; 435)</td></tr>\n",
+       "<tr><td colspan=\"3\" style=\"border-bottom: 1px solid black\"></td></tr><tr><td style=\"text-align: left\">Note:</td><td colspan=\"2\" style=\"text-align: right\"><sup>*</sup>p&lt;0.1; <sup>**</sup>p&lt;0.05; <sup>***</sup>p&lt;0.01</td></tr></table>"
+      ],
+      "text/plain": [
+       "<stargazer.stargazer.Stargazer at 0x26d69d1d190>"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Off by default\n",
+    "stargazer.show_T_Stat(True)\n",
+    "stargazer"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "stargazer.reset_params()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table style=\"text-align:center\"><tr><td colspan=\"3\" style=\"border-bottom: 1px solid black\"></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td colspan=\"2\"><em>Dependent variable: target</em></td></tr><tr><td style=\"text-align:left\"></td><tr><td style=\"text-align:left\"></td><td>(1)</td><td>(2)</td></tr>\n",
+       "<tr><td colspan=\"3\" style=\"border-bottom: 1px solid black\"></td></tr>\n",
+       "\n",
+       "<tr><td style=\"text-align:left\">ABP</td><td>416.673<sup>***</sup></td><td>397.581<sup>***</sup></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td>(280.087 , 553.258)</td><td>(258.292 , 536.871)</td></tr>\n",
+       "<tr><td style=\"text-align:left\">Age</td><td>37.241<sup></sup></td><td>24.703<sup></sup></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td>(-88.776 , 163.258)</td><td>(-103.858 , 153.264)</td></tr>\n",
+       "<tr><td style=\"text-align:left\">BMI</td><td>787.182<sup>***</sup></td><td>789.744<sup>***</sup></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td>(658.597 , 915.766)</td><td>(658.282 , 921.205)</td></tr>\n",
+       "<tr><td style=\"text-align:left\">S1</td><td></td><td>197.848<sup></sup></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td></td><td>(-84.805 , 480.501)</td></tr>\n",
+       "<tr><td style=\"text-align:left\">S2</td><td></td><td>-169.243<sup></sup></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td></td><td>(-449.797 , 111.312)</td></tr>\n",
+       "<tr><td style=\"text-align:left\">Sex</td><td>-106.576<sup>*</sup></td><td>-82.862<sup></sup></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td>(-228.677 , 15.525)</td><td>(-210.321 , 44.598)</td></tr>\n",
+       "<tr><td style=\"text-align:left\">const</td><td>152.133<sup>***</sup></td><td>152.133<sup>***</sup></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td>(146.527 , 157.740)</td><td>(146.526 , 157.741)</td></tr>\n",
+       "\n",
+       "<td colspan=\"3\" style=\"border-bottom: 1px solid black\"></td></tr>\n",
+       "<tr><td style=\"text-align: left\">Observations</td><td>442</td><td>442</td></tr><tr><td style=\"text-align: left\">R<sup>2</sup></td><td>0.400</td><td>0.403</td></tr><tr><td style=\"text-align: left\">Adjusted R<sup>2</sup></td><td>0.395</td><td>0.395</td></tr><tr><td style=\"text-align: left\">Residual Std. Error</td><td>59.976 (df=437)</td><td>59.982 (df=435)</td></tr><tr><td style=\"text-align: left\">F Statistic</td><td>72.913<sup>***</sup> (df=4; 437)</td><td>48.915<sup>***</sup> (df=6; 435)</td></tr>\n",
+       "<tr><td colspan=\"3\" style=\"border-bottom: 1px solid black\"></td></tr><tr><td style=\"text-align: left\">Note:</td><td colspan=\"2\" style=\"text-align: right\"><sup>*</sup>p&lt;0.1; <sup>**</sup>p&lt;0.05; <sup>***</sup>p&lt;0.01</td></tr></table>"
+      ],
+      "text/plain": [
+       "<stargazer.stargazer.Stargazer at 0x26d69d1d190>"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "stargazer.show_T_Stat(True)\n",
+    "stargazer.show_confidence_intervals(True)\n",
+    "stargazer"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "stargazer.reset_params()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table style=\"text-align:center\"><tr><td colspan=\"3\" style=\"border-bottom: 1px solid black\"></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td colspan=\"2\"><em>Dependent variable: target</em></td></tr><tr><td style=\"text-align:left\"></td><tr><td style=\"text-align:left\"></td><td>(1)</td><td>(2)</td></tr>\n",
+       "<tr><td colspan=\"3\" style=\"border-bottom: 1px solid black\"></td></tr>\n",
+       "\n",
+       "<tr><td style=\"text-align:left\">ABP</td><td>416.673<sup>***</sup></td><td>397.581<sup>***</sup></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td>(280.087 , 553.258)</td><td>(258.292 , 536.871)</td></tr>\n",
+       "<tr><td style=\"text-align:left\">Age</td><td>37.241<sup></sup></td><td>24.703<sup></sup></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td>(-88.776 , 163.258)</td><td>(-103.858 , 153.264)</td></tr>\n",
+       "<tr><td style=\"text-align:left\">BMI</td><td>787.182<sup>***</sup></td><td>789.744<sup>***</sup></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td>(658.597 , 915.766)</td><td>(658.282 , 921.205)</td></tr>\n",
+       "<tr><td style=\"text-align:left\">S1</td><td></td><td>197.848<sup></sup></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td></td><td>(-84.805 , 480.501)</td></tr>\n",
+       "<tr><td style=\"text-align:left\">S2</td><td></td><td>-169.243<sup></sup></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td></td><td>(-449.797 , 111.312)</td></tr>\n",
+       "<tr><td style=\"text-align:left\">Sex</td><td>-106.576<sup>*</sup></td><td>-82.862<sup></sup></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td>(-228.677 , 15.525)</td><td>(-210.321 , 44.598)</td></tr>\n",
+       "<tr><td style=\"text-align:left\">const</td><td>152.133<sup>***</sup></td><td>152.133<sup>***</sup></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td>(146.527 , 157.740)</td><td>(146.526 , 157.741)</td></tr>\n",
+       "\n",
+       "<td colspan=\"3\" style=\"border-bottom: 1px solid black\"></td></tr>\n",
+       "<tr><td style=\"text-align: left\">Observations</td><td>442</td><td>442</td></tr><tr><td style=\"text-align: left\">R<sup>2</sup></td><td>0.400</td><td>0.403</td></tr><tr><td style=\"text-align: left\">Adjusted R<sup>2</sup></td><td>0.395</td><td>0.395</td></tr><tr><td style=\"text-align: left\">Residual Std. Error</td><td>59.976 (df=437)</td><td>59.982 (df=435)</td></tr><tr><td style=\"text-align: left\">F Statistic</td><td>72.913<sup>***</sup> (df=4; 437)</td><td>48.915<sup>***</sup> (df=6; 435)</td></tr>\n",
+       "<tr><td colspan=\"3\" style=\"border-bottom: 1px solid black\"></td></tr><tr><td style=\"text-align: left\">Note:</td><td colspan=\"2\" style=\"text-align: right\"><sup>*</sup>p&lt;0.1; <sup>**</sup>p&lt;0.05; <sup>***</sup>p&lt;0.01</td></tr></table>"
+      ],
+      "text/plain": [
+       "<stargazer.stargazer.Stargazer at 0x26d69d1d190>"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "stargazer.show_confidence_intervals(True)\n",
+    "stargazer.show_T_Stat(True)\n",
+    "stargazer"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### confidence intervals always show if both methods are set to true. Both are set to False by default.\n",
+    "##### to display both, you simply can use stargazer.reset_params()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Test on Linear Models"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>district</th>\n",
+       "      <th>school</th>\n",
+       "      <th>county</th>\n",
+       "      <th>grades</th>\n",
+       "      <th>students</th>\n",
+       "      <th>teachers</th>\n",
+       "      <th>calworks</th>\n",
+       "      <th>lunch</th>\n",
+       "      <th>computer</th>\n",
+       "      <th>expenditure</th>\n",
+       "      <th>income</th>\n",
+       "      <th>english</th>\n",
+       "      <th>read</th>\n",
+       "      <th>math</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>75119</td>\n",
+       "      <td>Sunol Glen Unified</td>\n",
+       "      <td>Alameda</td>\n",
+       "      <td>KK-08</td>\n",
+       "      <td>195</td>\n",
+       "      <td>10.900000</td>\n",
+       "      <td>0.510200</td>\n",
+       "      <td>2.040800</td>\n",
+       "      <td>67</td>\n",
+       "      <td>6384.911133</td>\n",
+       "      <td>22.690001</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>691.599976</td>\n",
+       "      <td>690.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>61499</td>\n",
+       "      <td>Manzanita Elementary</td>\n",
+       "      <td>Butte</td>\n",
+       "      <td>KK-08</td>\n",
+       "      <td>240</td>\n",
+       "      <td>11.150000</td>\n",
+       "      <td>15.416700</td>\n",
+       "      <td>47.916698</td>\n",
+       "      <td>101</td>\n",
+       "      <td>5099.380859</td>\n",
+       "      <td>9.824000</td>\n",
+       "      <td>4.583333</td>\n",
+       "      <td>660.500000</td>\n",
+       "      <td>661.900024</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>61549</td>\n",
+       "      <td>Thermalito Union Elementary</td>\n",
+       "      <td>Butte</td>\n",
+       "      <td>KK-08</td>\n",
+       "      <td>1550</td>\n",
+       "      <td>82.900002</td>\n",
+       "      <td>55.032299</td>\n",
+       "      <td>76.322601</td>\n",
+       "      <td>169</td>\n",
+       "      <td>5501.954590</td>\n",
+       "      <td>8.978000</td>\n",
+       "      <td>30.000002</td>\n",
+       "      <td>636.299988</td>\n",
+       "      <td>650.900024</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>61457</td>\n",
+       "      <td>Golden Feather Union Elementary</td>\n",
+       "      <td>Butte</td>\n",
+       "      <td>KK-08</td>\n",
+       "      <td>243</td>\n",
+       "      <td>14.000000</td>\n",
+       "      <td>36.475399</td>\n",
+       "      <td>77.049202</td>\n",
+       "      <td>85</td>\n",
+       "      <td>7101.831055</td>\n",
+       "      <td>8.978000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>651.900024</td>\n",
+       "      <td>643.500000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>61523</td>\n",
+       "      <td>Palermo Union Elementary</td>\n",
+       "      <td>Butte</td>\n",
+       "      <td>KK-08</td>\n",
+       "      <td>1335</td>\n",
+       "      <td>71.500000</td>\n",
+       "      <td>33.108601</td>\n",
+       "      <td>78.427002</td>\n",
+       "      <td>171</td>\n",
+       "      <td>5235.987793</td>\n",
+       "      <td>9.080333</td>\n",
+       "      <td>13.857677</td>\n",
+       "      <td>641.799988</td>\n",
+       "      <td>639.900024</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   district                           school   county grades  students  \\\n",
+       "0     75119               Sunol Glen Unified  Alameda  KK-08       195   \n",
+       "1     61499             Manzanita Elementary    Butte  KK-08       240   \n",
+       "2     61549      Thermalito Union Elementary    Butte  KK-08      1550   \n",
+       "3     61457  Golden Feather Union Elementary    Butte  KK-08       243   \n",
+       "4     61523         Palermo Union Elementary    Butte  KK-08      1335   \n",
+       "\n",
+       "    teachers   calworks      lunch  computer  expenditure     income  \\\n",
+       "0  10.900000   0.510200   2.040800        67  6384.911133  22.690001   \n",
+       "1  11.150000  15.416700  47.916698       101  5099.380859   9.824000   \n",
+       "2  82.900002  55.032299  76.322601       169  5501.954590   8.978000   \n",
+       "3  14.000000  36.475399  77.049202        85  7101.831055   8.978000   \n",
+       "4  71.500000  33.108601  78.427002       171  5235.987793   9.080333   \n",
+       "\n",
+       "     english        read        math  \n",
+       "0   0.000000  691.599976  690.000000  \n",
+       "1   4.583333  660.500000  661.900024  \n",
+       "2  30.000002  636.299988  650.900024  \n",
+       "3   0.000000  651.900024  643.500000  \n",
+       "4  13.857677  641.799988  639.900024  "
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Fetching a dataset from the web\n",
+    "schools = sm.datasets.get_rdataset(\"CASchools\",\"AER\").data\t\n",
+    "\n",
+    "schools.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from statsmodels.formula.api import ols\n",
+    "\n",
+    "reg1 = ols(\"math ~ income\", data = schools).fit(cov_type = 'HC3')\n",
+    "reg2 = ols(\"math ~ income + computer\", data = schools).fit(cov_type = 'HC3')\n",
+    "reg3 = ols(\"math ~ income + computer + teachers\", data = schools).fit(cov_type = 'HC3')\n",
+    "\n",
+    "stargazer = Stargazer([reg1, reg2, reg3])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### With Standard Error"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table style=\"text-align:center\"><tr><td colspan=\"4\" style=\"border-bottom: 1px solid black\"></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td colspan=\"3\"><em>Dependent variable: math</em></td></tr><tr><td style=\"text-align:left\"></td><tr><td style=\"text-align:left\"></td><td>(1)</td><td>(2)</td><td>(3)</td></tr>\n",
+       "<tr><td colspan=\"4\" style=\"border-bottom: 1px solid black\"></td></tr>\n",
+       "\n",
+       "<tr><td style=\"text-align:left\">Intercept</td><td>625.539<sup>***</sup></td><td>626.452<sup>***</sup></td><td>627.294<sup>***</sup></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td>(1.878)</td><td>(1.963)</td><td>(1.952)</td></tr>\n",
+       "<tr><td style=\"text-align:left\">computer</td><td></td><td>-0.004<sup>***</sup></td><td>0.009<sup>**</sup></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td></td><td>(0.001)</td><td>(0.004)</td></tr>\n",
+       "<tr><td style=\"text-align:left\">income</td><td>1.815<sup>***</sup></td><td>1.840<sup>***</sup></td><td>1.801<sup>***</sup></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td>(0.116)</td><td>(0.120)</td><td>(0.120)</td></tr>\n",
+       "<tr><td style=\"text-align:left\">teachers</td><td></td><td></td><td>-0.033<sup>***</sup></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td></td><td></td><td>(0.009)</td></tr>\n",
+       "\n",
+       "<td colspan=\"4\" style=\"border-bottom: 1px solid black\"></td></tr>\n",
+       "<tr><td style=\"text-align: left\">Observations</td><td>420</td><td>420</td><td>420</td></tr><tr><td style=\"text-align: left\">R<sup>2</sup></td><td>0.489</td><td>0.499</td><td>0.512</td></tr><tr><td style=\"text-align: left\">Adjusted R<sup>2</sup></td><td>0.488</td><td>0.497</td><td>0.508</td></tr><tr><td style=\"text-align: left\">Residual Std. Error</td><td>13.420 (df=418)</td><td>13.306 (df=417)</td><td>13.150 (df=416)</td></tr><tr><td style=\"text-align: left\">F Statistic</td><td>244.502<sup>***</sup> (df=1; 418)</td><td>120.297<sup>***</sup> (df=2; 417)</td><td>91.382<sup>***</sup> (df=3; 416)</td></tr>\n",
+       "<tr><td colspan=\"4\" style=\"border-bottom: 1px solid black\"></td></tr><tr><td style=\"text-align: left\">Note:</td><td colspan=\"3\" style=\"text-align: right\"><sup>*</sup>p&lt;0.1; <sup>**</sup>p&lt;0.05; <sup>***</sup>p&lt;0.01</td></tr></table>"
+      ],
+      "text/plain": [
+       "<stargazer.stargazer.Stargazer at 0x26d6bbe7ed0>"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "stargazer"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### With T Statistic"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table style=\"text-align:center\"><tr><td colspan=\"4\" style=\"border-bottom: 1px solid black\"></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td colspan=\"3\"><em>Dependent variable: math</em></td></tr><tr><td style=\"text-align:left\"></td><tr><td style=\"text-align:left\"></td><td>(1)</td><td>(2)</td><td>(3)</td></tr>\n",
+       "<tr><td colspan=\"4\" style=\"border-bottom: 1px solid black\"></td></tr>\n",
+       "\n",
+       "<tr><td style=\"text-align:left\">Intercept</td><td>625.539<sup>***</sup></td><td>626.452<sup>***</sup></td><td>627.294<sup>***</sup></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td>(333.139)</td><td>(319.166)</td><td>(321.291)</td></tr>\n",
+       "<tr><td style=\"text-align:left\">computer</td><td></td><td>-0.004<sup>***</sup></td><td>0.009<sup>**</sup></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td></td><td>(-3.142)</td><td>(2.164)</td></tr>\n",
+       "<tr><td style=\"text-align:left\">income</td><td>1.815<sup>***</sup></td><td>1.840<sup>***</sup></td><td>1.801<sup>***</sup></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td>(15.637)</td><td>(15.322)</td><td>(15.066)</td></tr>\n",
+       "<tr><td style=\"text-align:left\">teachers</td><td></td><td></td><td>-0.033<sup>***</sup></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td></td><td></td><td>(-3.628)</td></tr>\n",
+       "\n",
+       "<td colspan=\"4\" style=\"border-bottom: 1px solid black\"></td></tr>\n",
+       "<tr><td style=\"text-align: left\">Observations</td><td>420</td><td>420</td><td>420</td></tr><tr><td style=\"text-align: left\">R<sup>2</sup></td><td>0.489</td><td>0.499</td><td>0.512</td></tr><tr><td style=\"text-align: left\">Adjusted R<sup>2</sup></td><td>0.488</td><td>0.497</td><td>0.508</td></tr><tr><td style=\"text-align: left\">Residual Std. Error</td><td>13.420 (df=418)</td><td>13.306 (df=417)</td><td>13.150 (df=416)</td></tr><tr><td style=\"text-align: left\">F Statistic</td><td>244.502<sup>***</sup> (df=1; 418)</td><td>120.297<sup>***</sup> (df=2; 417)</td><td>91.382<sup>***</sup> (df=3; 416)</td></tr>\n",
+       "<tr><td colspan=\"4\" style=\"border-bottom: 1px solid black\"></td></tr><tr><td style=\"text-align: left\">Note:</td><td colspan=\"3\" style=\"text-align: right\"><sup>*</sup>p&lt;0.1; <sup>**</sup>p&lt;0.05; <sup>***</sup>p&lt;0.01</td></tr></table>"
+      ],
+      "text/plain": [
+       "<stargazer.stargazer.Stargazer at 0x26d6bbe7ed0>"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "stargazer.show_T_Stat(True)\n",
+    "stargazer"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Lets Make it look nicer"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "Math Scores and School Resources<br><table style=\"text-align:center\"><tr><td colspan=\"4\" style=\"border-bottom: 1px solid black\"></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td colspan=\"3\"><em>Dependent variable: math</em></td></tr><tr><td style=\"text-align:left\"></td><tr><td></td><td colspan=\"1\">Reg 1</td><td colspan=\"1\">Reg 2</td><td colspan=\"1\">Reg 3</td></tr>\n",
+       "<tr><td colspan=\"4\" style=\"border-bottom: 1px solid black\"></td></tr>\n",
+       "\n",
+       "<tr><td style=\"text-align:left\">Intercept</td><td>625.539<sup>***</sup></td><td>626.452<sup>***</sup></td><td>627.294<sup>***</sup></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td>(333.139)</td><td>(319.166)</td><td>(321.291)</td></tr>\n",
+       "<tr><td style=\"text-align:left\">computer</td><td></td><td>-0.004<sup>***</sup></td><td>0.009<sup>**</sup></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td></td><td>(-3.142)</td><td>(2.164)</td></tr>\n",
+       "<tr><td style=\"text-align:left\">income</td><td>1.815<sup>***</sup></td><td>1.840<sup>***</sup></td><td>1.801<sup>***</sup></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td>(15.637)</td><td>(15.322)</td><td>(15.066)</td></tr>\n",
+       "<tr><td style=\"text-align:left\">teachers</td><td></td><td></td><td>-0.033<sup>***</sup></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td></td><td></td><td>(-3.628)</td></tr>\n",
+       "\n",
+       "<td colspan=\"4\" style=\"border-bottom: 1px solid black\"></td></tr>\n",
+       "<tr><td style=\"text-align: left\">Observations</td><td>420</td><td>420</td><td>420</td></tr><tr><td style=\"text-align: left\">R<sup>2</sup></td><td>0.489</td><td>0.499</td><td>0.512</td></tr><tr><td style=\"text-align: left\">Adjusted R<sup>2</sup></td><td>0.488</td><td>0.497</td><td>0.508</td></tr><tr><td style=\"text-align: left\">Residual Std. Error</td><td>13.420 (df=418)</td><td>13.306 (df=417)</td><td>13.150 (df=416)</td></tr><tr><td style=\"text-align: left\">F Statistic</td><td>244.502<sup>***</sup> (df=1; 418)</td><td>120.297<sup>***</sup> (df=2; 417)</td><td>91.382<sup>***</sup> (df=3; 416)</td></tr>\n",
+       "<tr><td colspan=\"4\" style=\"border-bottom: 1px solid black\"></td></tr><tr><td style=\"text-align: left\">Note:</td><td colspan=\"3\" style=\"text-align: right\"><sup>*</sup>p&lt;0.1; <sup>**</sup>p&lt;0.05; <sup>***</sup>p&lt;0.01</td></tr><tr><td colspan=\"4\" style=\"text-align: right\">This is a stargazer table with T (or z) stats!</td></tr></table>"
+      ],
+      "text/plain": [
+       "<stargazer.stargazer.Stargazer at 0x26d6bbe7ed0>"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "stargazer.title('Math Scores and School Resources')\n",
+    "stargazer.add_custom_notes(['This is a stargazer table with T (or z) stats!'])\n",
+    "stargazer.custom_columns(['Reg 1', 'Reg 2','Reg 3'], [1, 1,1])\n",
+    "stargazer.show_model_numbers(False)\n",
+    "stargazer"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## And The result in latex\n",
+    "\n",
+    "**I had to use a separate latex editor to render the table, so the image is included in this directory**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\\begin{table}[!htbp] \\centering\n",
+      "  \\caption{Math Scores and School Resources}\n",
+      "\\begin{tabular}{@{\\extracolsep{5pt}}lccc}\n",
+      "\\\\[-1.8ex]\\hline\n",
+      "\\hline \\\\[-1.8ex]\n",
+      "& \\multicolumn{3}{c}{\\textit{Dependent variable: math}} \\\n",
+      "\\cr \\cline{2-4}\n",
+      "\\\\[-1.8ex] & \\multicolumn{1}{c}{Reg 1} & \\multicolumn{1}{c}{Reg 2} & \\multicolumn{1}{c}{Reg 3}  \\\\\n",
+      "\\hline \\\\[-1.8ex]\n",
+      " Intercept & 625.539$^{***}$ & 626.452$^{***}$ & 627.294$^{***}$ \\\\\n",
+      "& (1.878) & (1.963) & (1.952) \\\\\n",
+      " computer & & -0.004$^{***}$ & 0.009$^{**}$ \\\\\n",
+      "& & (0.001) & (0.004) \\\\\n",
+      " income & 1.815$^{***}$ & 1.840$^{***}$ & 1.801$^{***}$ \\\\\n",
+      "& (0.116) & (0.120) & (0.120) \\\\\n",
+      " teachers & & & -0.033$^{***}$ \\\\\n",
+      "& & & (0.009) \\\\\n",
+      "\\hline \\\\[-1.8ex]\n",
+      " Observations & 420 & 420 & 420 \\\\\n",
+      " $R^2$ & 0.489 & 0.499 & 0.512 \\\\\n",
+      " Adjusted $R^2$ & 0.488 & 0.497 & 0.508 \\\\\n",
+      " Residual Std. Error & 13.420 (df=418) & 13.306 (df=417) & 13.150 (df=416) \\\\\n",
+      " F Statistic & 244.502$^{***}$ (df=1; 418) & 120.297$^{***}$ (df=2; 417) & 91.382$^{***}$ (df=3; 416) \\\\\n",
+      "\\hline\n",
+      "\\hline \\\\[-1.8ex]\n",
+      "\\textit{Note:} & \\multicolumn{3}{r}{$^{*}$p$<$0.1; $^{**}$p$<$0.05; $^{***}$p$<$0.01} \\\\\n",
+      "\\multicolumn{4}{r}\\textit{This is a stargazer table with T (or z) stats!} \\\\\n",
+      "\\end{tabular}\n",
+      "\\end{table}\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(stargazer.render_latex())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "star_contr",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
this is a pull request for Issue "stat in parenthesis #85" I have added a method to the stargazer class very similar to the show_confidence_intervals() method. I have tested my version against run_test.py and also included my own tests. Also, here is the latex version, I forgot to add it.

[table_with_tstat.pdf](https://github.com/StatsReporting/stargazer/files/14528385/table_with_tstat.pdf)
