### PR TITLE
Support for `pyfixest`

### DIFF
--- a/stargazer/stargazer.py
+++ b/stargazer/stargazer.py
@@ -144,6 +144,7 @@ class Stargazer:
         for use or modification. They should not be able to
         be modified by any rendering parameters.
         """
+
         self.model_data = []
         for m in self.models:
             self.model_data.append(self.extract_model_data(m))
@@ -344,7 +345,7 @@ class Renderer:
     def __init__(self, table, **kwargs):
         """
         Initialize a new renderer.
-        
+
         "table": Stargazer object to render
         """
 

--- a/stargazer/translators/__init__.py
+++ b/stargazer/translators/__init__.py
@@ -13,3 +13,10 @@ try:
 except ModuleNotFoundError:
     # linearmodels not found
     pass
+
+### PYFIXEST ###
+try:
+    from .pyfixest import classes
+except ModuleNotFoundError:
+    # pyfixest not found
+    pass

--- a/stargazer/translators/pyfixest.py
+++ b/stargazer/translators/pyfixest.py
@@ -1,0 +1,53 @@
+"""
+Compatibility layer with results from pyfixest.
+"""
+
+from ..starlib import _extract_feature
+
+from . import register_class
+from pyfixest.estimation.feols_ import Feols
+from pyfixest.estimation.feiv_ import Feiv
+from pyfixest.estimation.fepois_ import Fepois
+
+# For features that are simple attributes of "model", establish the
+# mapping with internal name:
+
+pyfixest_map = {
+                   'r2' : '_r2',
+                   'cov_names' : '_coefnames',
+                   'nobs' : '_N',
+                   }
+
+def extract_model_data(model):
+
+    data = {}
+    for key, val in pyfixest_map.items():
+        data[key] = _extract_feature(model, val)
+
+    data['dependent_variable'] = model._fml.split("~")[0].replace(" ", "")
+    data['cov_values'] = model.coef()
+    data['cov_std_err'] = model.se()
+    data['p_values'] = model.pvalue()
+
+    data['resid_std_err'] = None
+    data['degree_freedom_resid'] = None
+    data["f_statistic"] = None
+    data["f_p_value"] = None
+    data["r2_adj"] = None
+    data["pseudo_r2"] = None
+
+
+    #data['conf_int_low_values'] = model._conf_int[:,0]
+    #data['conf_int_high_values'] = model._conf_int[:,1]
+
+    return data
+
+
+classes = [(Feols, extract_model_data),
+           (Fepois, extract_model_data),
+           (Feiv, extract_model_data)
+           ]
+
+for klass, translator in classes:
+    register_class(klass, translator)
+

--- a/stargazer/translators/pyfixest.py
+++ b/stargazer/translators/pyfixest.py
@@ -28,6 +28,9 @@ def extract_model_data(model):
     data['cov_values'] = model.coef()
     data['cov_std_err'] = model.se()
     data['p_values'] = model.pvalue()
+    data['conf_int_low_values'] = model.confint().iloc[:,0]
+    data['conf_int_high_values'] = model.confint().iloc[:,1]
+
 
     data['resid_std_err'] = None
     data['degree_freedom_resid'] = None
@@ -35,10 +38,6 @@ def extract_model_data(model):
     data["f_p_value"] = None
     data["r2_adj"] = None
     data["pseudo_r2"] = None
-
-
-    #data['conf_int_low_values'] = model._conf_int[:,0]
-    #data['conf_int_high_values'] = model._conf_int[:,1]
 
     return data
 


### PR DESCRIPTION
Hi @toobaz - this is a draft PR to add basic support for the [pyfixest ](https://github.com/py-econometrics/pyfixest) project. 

It's still a WIP - I would like to add information on the fixed effects employed in a given model & add support for a range of additional model statistics that pyfixest is not yet computing.  

This is how it currently looks: 

```python
%load_ext autoreload
%autoreload 2

import pyfixest as pf
from stargazer.stargazer import Stargazer

fit1 = pf.feols("Y ~ X1 + X2", data = pf.get_data())
fit2 = pf.feols("Y ~ X1 + X2 | f1", data = pf.get_data())
fit3 = pf.feols("Y2 ~ X1 + X2| f1", data = pf.get_data())

Stargazer([fit1, fit2, fit3])
```

![image](https://github.com/StatsReporting/stargazer/assets/19531450/1ff5cf42-83db-411f-bdfd-9fd0191dab7a)


Would you be happy to accept such a PR? Is there anything else I should take a look at? 

Pinging @asquidy as he'd expressed interest in this feature =) 

Merging this PR would close https://github.com/py-econometrics/pyfixest/issues/283. 

All the best, Alex